### PR TITLE
1.0.0 beta.4

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,18 @@
+
+# EditorConfig is awesome: https://EditorConfig.org
+
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+charset = utf-8
+
+[*.{js, ts, json, yml}]
+indent_style = space
+indent_size = 2
+
+[*.md]
+indent_style = space
+indent_size = 4

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ yarn.lock
 .vscode
 
 # Tests
+*.tsbuildinfo
 test/credentials.js
 docs
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ before_script:
 jobs:
   include:
     - stage: deploy
-      script: bash ./deploy/travis-deploy.sh
+      script: bash ./deploy/travis.sh
 cache:
   directories:
     - node_modules

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
         // Passing an error object will emit the `error` event.
     });
     ```
+- Added `PaginationEmbed#setEmojisFunctionAfterNavigation` method. This allows function emojis to either be the first/last set to be deployed before/after navigation emojis.
+  -  Default: `false`.
 
 ## Changed
 - PaginationEmbed no longer emits an event when there is no listener (invoking `.on`/`.once`)
@@ -32,7 +34,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Fixed
 - Fixed possibly unnecessary API call on awaiting emoji reacts timeout.
-  - `clientMessage.delete()` now precedes `clientMessage.reactions.removeAll()`
+  - `clientMessage#delete` now precedes `clientMessage.reactions#removeAll`
 
 ## [1.0.0-beta.3] - 2019-03-31
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,35 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+## [1.0.0-beta.4] - 2019-04-26
+[**Updating from `v0.8.0`**](UPDATING_V1.md#api-changes) (Updated, please read again)
+
+## Added
+- Added ability to stop the instance from awaiting emoji reacts with function emojis:
+    ```js
+    <PaginationEmbed>.addFunctionEmoji('🛑', () => {
+        // Either
+        throw 'stopped';
+
+        // or
+        return Promise.reject('stopped');
+
+        // will stop the instance from awaiting reacts.
+        // Passing an error object will emit the `error` event.
+    });
+    ```
+
+## Changed
+- PaginationEmbed no longer emits an event when there is no listener (invoking `.on`/`.once`)
+
+## Removed
+- Option `prepare` for `clientAssets` has been removed. This affects:
+    - Setting the `channel` property is a must now. (Used to be either `clientAssets.message` or `channel` must be set)
+
+## Fixed
+- Fixed possibly unnecessary API call on awaiting emoji reacts timeout.
+  - `clientMessage.delete()` now precedes `clientMessage.reactions.removeAll()`
+
 ## [1.0.0-beta.3] - 2019-03-31
 ### Added
 - More TypeScript notices
@@ -31,7 +60,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   ```ts
   import Embeds from 'discord-paginationembed/typings/Embeds';
   import FieldsEmbed from 'discord-paginationembed/typings/FieldsEmbed';
-  
+
   // Unlikely
   import { IClientAssets } from 'discord-paginationembed/typings/base';
   ```
@@ -130,7 +159,7 @@ return 'done!';
 ### Added
   - `functionEmoji` - customised emojis with specific function (#8)
   - `deleteOnTimeout` - option to delete the message upon `awaiting response` timeout (#11)
-  - `test` folder for `FieldsEmbed` and `Embeds` test bot 
+  - `test` folder for `FieldsEmbed` and `Embeds` test bot
 
 ### Changed
   - Major [documentation](https://gazmull.github.io/discord-paginationembed) changes
@@ -177,7 +206,8 @@ return 'done!';
 ### Added
   - Initial release
 
-[Unreleased]: https://github.com/gazmull/discord-paginationembed/compare/1.0.0-beta.3...HEAD
+[Unreleased]: https://github.com/gazmull/discord-paginationembed/compare/1.0.0-beta.4...HEAD
+[1.0.0-beta.4]: https://github.com/gazmull/discord-paginationembed/compare/1.0.0-beta.3...1.0.0-beta.4
 [1.0.0-beta.3]: https://github.com/gazmull/discord-paginationembed/compare/1.0.0-beta.2...1.0.0-beta.3
 [1.0.0-beta.2]: https://github.com/gazmull/discord-paginationembed/compare/1.0.0-beta.1...1.0.0-beta.2
 [1.0.0-beta.1]: https://github.com/gazmull/discord-paginationembed/compare/1.0.0-beta.0...1.0.0-beta.1

--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -1,4 +1,4 @@
-const { sync: del } = require('del');
+const { default: del } = require('del');
 const gulp = require('gulp');
 const ts = require('gulp-typescript');
 const tslint = require('gulp-tslint');
@@ -17,11 +17,7 @@ const terserFiles = {
   src: paths.bin + '/**/*.js'
 };
 
-gulp.task('clean', () => {
-  del([ paths.bin, paths.typings ]);
-
-  return Promise.resolve(true);
-});
+gulp.task('clean', () => del([ paths.bin, paths.typings ]));
 
 gulp.task('lint', () => {
   return gulp.src(paths.src)

--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@ A pagination utility for MessageEmbed in Discord.JS
 
 [![Discord Server](https://discordapp.com/api/guilds/370614673122263041/embed.png)](https://discord.gg/eDUzT87)
 [![Travis (.org) branch](https://img.shields.io/travis/gazmull/discord-paginationembed/master.svg?logo=travis&style=flat-square)](https://travis-ci.org/gazmull/discord-paginationembed)
-[![npm bundle size](https://img.shields.io/bundlephobia/min/discord-paginationembed.svg?logo=npm&style=flat-square)](https://nodei.co/npm/discord-paginationembed/)
 [![npm peer dependency version](https://img.shields.io/npm/dependency-version/discord-paginationembed/peer/discord.js.svg?logo=npm&style=flat-square)](https://nodei.co/npm/discord-paginationembed/)
 [![npm type definitions](https://img.shields.io/npm/types/discord-paginationembed.svg?logo=npm&style=flat-square)](https://nodei.co/npm/discord-paginationembed/)
 
@@ -18,7 +17,7 @@ A pagination utility for MessageEmbed in Discord.JS
 - ✔ [**Documentation**](https://gazmull.github.io/discord-paginationembed "Go to My Documentation") for online references
 - ✔ **Asynchronous** workflow
 - ✔ Supports [**Discord.JS v12**](https://discord.js.org/#/docs/main/master/general/welcome "Go to Discord.JS Master Documentation")
-- ❌ Currently does not support **Discord.JS v11**
+- ❌ Currently does not support **Discord.JS v11** (Last version: [**v0.7.7-v11**](https://github.com/gazmull/discord-paginationembed/tree/0.7.7-v11))
 - ❔ Nothing found within docs or need a nudge? You may visit the [**Discord server**](https://discord.gg/eDUzT87)
 
 ## 🛠 Installation
@@ -113,7 +112,9 @@ const FieldsEmbed = new Pagination.FieldsEmbed()
       field.name = 'Name';
     else
       field.name = 'Na🅱e';
-  });
+  })
+  // Sets whether function emojis should be deployed after navigation emojis
+  .setEmojisFunctionAfterNavigation(false);
 
 FieldsEmbed.embed
   .setColor(0xFF00AE)

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A pagination utility for MessageEmbed in Discord.JS
 
 ## 📣 Notice Board
 - [**Changelog**](https://github.com/gazmull/discord-paginationembed/blob/master/CHANGELOG.md)
-- [**Updating from `v0.8.0` to `v1.0.0`**](https://github.com/gazmull/discord-paginationembed/blob/master/UPDATING_V1.md)
+- [**Updating from `v0.8.0` to `v1.0.0`**](https://github.com/gazmull/discord-paginationembed/blob/master/UPDATING_V1.md) — Updated **2019-04-26**
 
 ## 🎉 Welcome
 - ✔ **Typings** included
@@ -175,6 +175,11 @@ const Embeds = new PaginationEmbed.Embeds()
   .setFooter('Test Footer Text')
   .setURL('https://gazmull.github.io/discord-paginationembed')
   .setColor(0xFF00AE)
+  // Sets the client's assets to utilise. Available options:
+  //  - message: the client's Message object (edits the message instead of sending new one for this instance)
+  //  - prompt: custom content for the message sent when prompted to jump to a page
+  //      {{user}} is the placeholder for the user mention
+  .setClientAssets({ message, prompt: 'Page plz {{user}}' })
   .setDeleteOnTimeout(true)
   .setDisabledNavigationEmojis(['DELETE'])
   .setFunctionEmojis({

--- a/UPDATING_V1.md
+++ b/UPDATING_V1.md
@@ -1,13 +1,11 @@
 # Updating From `v0.8.0`
 
 ## Notice
-If you are from **stable branch (v11)**, then this will no longer work for you as its support has been suspended (this package only).
+- This documentation will be changed without prior notice for any changes in v1's source code. In some cases, commit messages will notify everyone that this documentation has been changed.
+- If you are from **stable branch (v11)**, then this will no longer work for you as its support has been suspended (this package only). Last version of v11 branch: `v0.7.7-v11`
 
 ## Installation
 New way to install the utility is from NPM: `npm install discord-paginationembed`
-
-### ❗ Heads Up!
-There might be a decision to suddenly resume support for **v11**. So if it ever happens, **master branch (v12)**'s installation would be `npm install discord-paginationembed@canary`
 
 ## TypeScript
 For importing types to your TypeScript project:
@@ -29,6 +27,14 @@ const fieldsEmbed = new FieldsEmbed<LegendaryInterface>();
 
 ## API Changes
 ### `showPageIndicator` ➡ `setPageIndicator`
+> Since **v1.0.0-beta.2**
+
+---
+
+### `channel` **must** be set
+> Since **v1.0.0-beta.4**
+
+Before, it's either `clientAssets.message` or `channel` is set, but this makes an unnecessary API call (could lead to ratelimit) via sending/editing a dummy message with `clientAssets.prepare`'s content. By removing `clientAssets.prepare`, setting the channel is now a must while `clientAssets.message` is still optional.
 
 ---
 
@@ -51,7 +57,9 @@ new FieldsEmbed()
 ---
 
 ### `clientMessage` ➡ `clientAssets`
-`clientMessage` has been replaced with `clientAssets`: similar API but the latter takes an object as the only parameter. Another option, `prompt`, has been added for customising the message content for `when prompted to jump to a page`.
+`clientMessage` has been replaced with `clientAssets`: similar API but the latter takes an object as the only parameter. Option `prompt` was added for customising the content for message to send when prompted to jump to a page.
+
+- [**since v1.0.0-beta.4**] `prepare` option has been removed due to unnecessary API call.
 
 #### `clientMessage` (Old way)
 ```js
@@ -65,7 +73,6 @@ new FieldsEmbed()
 new FieldsEmbed()
   .setClientAssets({
     message: clientMessage,
-    prepare: 'Preparing...', // Option for message content while preparing the paginated embed
     prompt: 'Yo {{user}} what page?' // Option for message content when prompted to jump to a page.
   });
 ```

--- a/bin/Embeds.js
+++ b/bin/Embeds.js
@@ -22,7 +22,7 @@ exports.Embeds = class extends t.PaginationEmbed {
     return this;
   }
   async build() {
-    return this.pages = this.array.length, await this._verify(), this.emit("start"), 
+    return this.pages = this.array.length, await this._verify(), this.listenerCount("start") && this.emit("start"), 
     this._loadList();
   }
   setArray(t) {
@@ -90,7 +90,9 @@ exports.Embeds = class extends t.PaginationEmbed {
   }
   async _loadList(r = !0) {
     const t = this.pageIndicator ? 1 === this.pages ? null : `Page ${this.page} of ${this.pages}` : null;
-    return await this.clientAssets.message.edit(t, {
+    return this.clientAssets.message ? await this.clientAssets.message.edit(t, {
+      embed: this.currentEmbed
+    }) : this.clientAssets.message = await this.channel.send(t, {
       embed: this.currentEmbed
     }), super._loadList(r);
   }

--- a/bin/FieldsEmbed.js
+++ b/bin/FieldsEmbed.js
@@ -20,7 +20,7 @@ exports.FieldsEmbed = class extends t.PaginationEmbed {
     this.embed.fields = [];
     for (const t of e) "function" == typeof t.value ? this.formatField(t.name, t.value, t.inline) : this.embed.addField(t.name, t.value, t.inline);
     if (!this.embed.fields.filter(e => "function" == typeof e.value).length) throw new Error("Cannot invoke FieldsEmbed class without at least one formatted field to paginate.");
-    return this.emit("start"), this._loadList();
+    return this.listenerCount("start") && this.emit("start"), this._loadList();
   }
   formatField(e, t, s = !0) {
     if ("function" != typeof t) throw new TypeError("formatField() value parameter only takes a function.");
@@ -42,7 +42,9 @@ exports.FieldsEmbed = class extends t.PaginationEmbed {
   }
   async _loadList(e = !0) {
     const t = await this._drawList(), s = this.pageIndicator ? 1 === this.pages ? null : `Page ${this.page} of ${this.pages}` : null;
-    return await this.clientAssets.message.edit(s, {
+    return this.clientAssets.message ? await this.clientAssets.message.edit(s, {
+      embed: t
+    }) : this.clientAssets.message = await this.channel.send(s, {
       embed: t
     }), super._loadList(e);
   }

--- a/bin/base/index.js
+++ b/bin/base/index.js
@@ -4,9 +4,9 @@ Object.defineProperty(exports, "__esModule", {
   value: !0
 });
 
-const e = require("events"), t = "Client's message was deleted before being processed.";
+const t = require("events"), e = "Client's message was deleted before being processed.";
 
-exports.PaginationEmbed = class extends e.EventEmitter {
+exports.PaginationEmbed = class extends t.EventEmitter {
   constructor() {
     super(), this.authorizedUsers = [], this.channel = null, this.clientAssets = {}, 
     this.pageIndicator = !0, this.deleteOnTimeout = !1, this.page = 1, this.timeout = 3e4, 
@@ -26,47 +26,46 @@ exports.PaginationEmbed = class extends e.EventEmitter {
   build() {
     throw new Error("Cannot invoke this class. Invoke with [PaginationEmbed.Embeds] or [PaginationEmbed.FieldsEmbed] instead.");
   }
-  addFunctionEmoji(e, t) {
-    if (!(t instanceof Function)) throw new TypeError(`Callback for ${e} must be a function type.`);
+  addFunctionEmoji(t, e) {
+    if (!(e instanceof Function)) throw new TypeError(`Callback for ${t} must be a function type.`);
     return Object.assign(this.functionEmojis, {
-      [e]: t
+      [t]: e
     }), this;
   }
-  deleteFunctionEmoji(e) {
-    if (!(e in this.functionEmojis)) throw new Error(`${e} function emoji does not exist.`);
-    return delete this.functionEmojis[e], this;
+  deleteFunctionEmoji(t) {
+    if (!(t in this.functionEmojis)) throw new Error(`${t} function emoji does not exist.`);
+    return delete this.functionEmojis[t], this;
   }
   resetEmojis() {
-    for (const e in this.functionEmojis) delete this.functionEmojis[e];
+    for (const t in this.functionEmojis) delete this.functionEmojis[t];
     return this.navigationEmojis = this._defaultNavigationEmojis, this;
   }
-  setArray(e) {
-    if (!Array.isArray(e) || !Boolean(e.length)) throw new TypeError("Cannot invoke PaginationEmbed class without a valid array to paginate.");
-    return this.array = e, this;
+  setArray(t) {
+    if (!Array.isArray(t) || !Boolean(t.length)) throw new TypeError("Cannot invoke PaginationEmbed class without a valid array to paginate.");
+    return this.array = t, this;
   }
-  setAuthorizedUsers(e) {
-    if (!Array.isArray(e)) throw new TypeError("Cannot invoke PaginationEmbed class without a valid array.");
-    return this.authorizedUsers = e, this;
+  setAuthorizedUsers(t) {
+    if (!Array.isArray(t)) throw new TypeError("Cannot invoke PaginationEmbed class without a valid array.");
+    return this.authorizedUsers = t, this;
   }
-  setChannel(e) {
-    return this.channel = e, this;
+  setChannel(t) {
+    return this.channel = t, this;
   }
-  setClientAssets(e) {
-    if (!e) throw new TypeError("Cannot accept assets options as a non-object type.");
-    const {message: t} = e;
-    let {prepare: i, prompt: s} = e;
-    return i || (i = "Preparing..."), s || (s = "{{user}}, To what page would you like to jump? Say `cancel` or `0` to cancel the prompt."), 
+  setClientAssets(t) {
+    if (!t) throw new TypeError("Cannot accept assets options as a non-object type.");
+    const {message: e} = t;
+    let {prompt: i} = t;
+    return i || (i = "{{user}}, To what page would you like to jump? Say `cancel` or `0` to cancel the prompt."), 
     Object.assign(this.clientAssets, {
-      message: t,
-      prepare: i,
-      prompt: s
+      message: e,
+      prompt: i
     }), this;
   }
-  setDisabledNavigationEmojis(e) {
-    if (!Array.isArray(e)) throw new TypeError("Cannot invoke PaginationEmbed class without a valid array.");
-    const t = [], i = [];
-    for (let s of e) {
-      if (s = "string" == typeof s ? s.toUpperCase() : s, [ "BACK", "JUMP", "FORWARD", "DELETE", "ALL" ].includes(s) || t.push(s), 
+  setDisabledNavigationEmojis(t) {
+    if (!Array.isArray(t)) throw new TypeError("Cannot invoke PaginationEmbed class without a valid array.");
+    const e = [], i = [];
+    for (let s of t) {
+      if (s = "string" == typeof s ? s.toUpperCase() : s, [ "BACK", "JUMP", "FORWARD", "DELETE", "ALL" ].includes(s) || e.push(s), 
       "ALL" === s) {
         this.navigationEmojis = {
           back: null,
@@ -79,77 +78,81 @@ exports.PaginationEmbed = class extends e.EventEmitter {
       i.push(s), s = s.toLowerCase(), this._disabledNavigationEmojiValues.push(this.navigationEmojis[s]), 
       this.navigationEmojis[s] = null;
     }
-    if (t.length) throw new TypeError(`Cannot invoke PaginationEmbed class with invalid navigation emoji(s): ${t.join(", ")}.`);
+    if (e.length) throw new TypeError(`Cannot invoke PaginationEmbed class with invalid navigation emoji(s): ${e.join(", ")}.`);
     return this.disabledNavigationEmojis = i, this;
   }
-  setFunctionEmojis(e) {
-    for (const t in e) {
-      if (!t) continue;
-      const i = e[t];
-      this.addFunctionEmoji(t, i);
+  setFunctionEmojis(t) {
+    for (const e in t) {
+      if (!e) continue;
+      const i = t[e];
+      this.addFunctionEmoji(e, i);
     }
     return this;
   }
-  setNavigationEmojis(e) {
-    return Object.assign(this.navigationEmojis, e), this;
+  setNavigationEmojis(t) {
+    return Object.assign(this.navigationEmojis, t), this;
   }
-  setPage(e) {
-    const t = "string" == typeof e;
-    if (isNaN(e) && !t) throw new TypeError("setPage() only accepts number/string type.");
-    const i = "back" === e ? 1 === this.page ? this.page : this.page - 1 : this.page === this.pages ? this.pages : this.page + 1;
-    return this.page = t ? i : e, this;
+  setPage(t) {
+    const e = "string" == typeof t;
+    if (isNaN(t) && !e) throw new TypeError("setPage() only accepts number/string type.");
+    const i = "back" === t ? 1 === this.page ? this.page : this.page - 1 : this.page === this.pages ? this.pages : this.page + 1;
+    return this.page = e ? i : t, this;
   }
-  setTimeout(e) {
-    if ("number" != typeof e) throw new TypeError("setTimeout() only accepts number type.");
-    return this.timeout = e, this;
+  setTimeout(t) {
+    if ("number" != typeof t) throw new TypeError("setTimeout() only accepts number type.");
+    return this.timeout = t, this;
   }
-  setPageIndicator(e) {
-    if ("boolean" != typeof e) throw new TypeError("setPageIndicator() only accepts boolean type.");
-    return this.pageIndicator = e, this;
+  setPageIndicator(t) {
+    if ("boolean" != typeof t) throw new TypeError("setPageIndicator() only accepts boolean type.");
+    return this.pageIndicator = t, this;
   }
-  setDeleteOnTimeout(e) {
-    if ("boolean" != typeof e) throw new TypeError("deleteOnTimeout() only accepts boolean type.");
-    return this.deleteOnTimeout = e, this;
+  setDeleteOnTimeout(t) {
+    if ("boolean" != typeof t) throw new TypeError("deleteOnTimeout() only accepts boolean type.");
+    return this.deleteOnTimeout = t, this;
   }
   async _verify() {
-    if (this.setClientAssets(this.clientAssets), !this.clientAssets.message && !this.channel) throw new Error("Cannot invoke PaginationEmbed class without either a message object or a channel object set.");
-    if (!(this.page >= 1 && this.page <= this.pages)) throw new Error(`Page number is out of bounds. Max pages: ${this.pages}`);
-    const e = this.clientAssets.message ? await this.clientAssets.message.edit(this.clientAssets.prepare) : await this.channel.send(this.clientAssets.prepare);
-    if (this.clientAssets.message = e, e.guild) {
-      const t = e.channel.permissionsFor(e.client.user).missing([ "ADD_REACTIONS", "MANAGE_MESSAGES", "EMBED_LINKS", "VIEW_CHANNEL", "SEND_MESSAGES" ]);
-      if (t.length) throw new Error(`Cannot invoke PaginationEmbed class without required permissions: ${t.join(", ")}`);
+    if (this.setClientAssets(this.clientAssets), !this.channel) throw new Error("Cannot invoke PaginationEmbed class without a channel object set.");
+    if (!(this.page >= 1 && this.page <= this.pages)) throw new RangeError(`Page number is out of bounds. Max pages: ${this.pages}`);
+    return this._checkPermissions();
+  }
+  async _checkPermissions() {
+    const t = this.channel;
+    if (t.guild) {
+      const e = t.permissionsFor(t.client.user).missing([ "ADD_REACTIONS", "MANAGE_MESSAGES", "EMBED_LINKS", "VIEW_CHANNEL", "SEND_MESSAGES" ]);
+      if (e.length) throw new Error(`Cannot invoke PaginationEmbed class without required permissions: ${e.join(", ")}`);
     }
     return !0;
   }
-  _enabled(e) {
-    return !this.disabledNavigationEmojis.includes("ALL") && !this.disabledNavigationEmojis.includes(e);
+  _enabled(t) {
+    return !this.disabledNavigationEmojis.includes("ALL") && !this.disabledNavigationEmojis.includes(t);
   }
   async _drawNavigation() {
-    if (Object.keys(this.functionEmojis).length) for (const e in this.functionEmojis) await this.clientAssets.message.react(e);
+    if (Object.keys(this.functionEmojis).length) for (const t in this.functionEmojis) await this.clientAssets.message.react(t);
     return this._enabled("BACK") && this.pages > 1 && await this.clientAssets.message.react(this.navigationEmojis.back), 
     this._enabled("JUMP") && this.pages > 2 && await this.clientAssets.message.react(this.navigationEmojis.jump), 
     this._enabled("FORWARD") && this.pages > 1 && await this.clientAssets.message.react(this.navigationEmojis.forward), 
     this._enabled("DELETE") && await this.clientAssets.message.react(this.navigationEmojis.delete), 
     this._awaitResponse();
   }
-  _loadList(e = !0) {
-    if (e) return this._drawNavigation();
+  _loadList(t = !0) {
+    if (t) return this._drawNavigation();
   }
-  async _loadPage(e = 1) {
-    return this.setPage(e), await this._loadList(!1), this._awaitResponse();
+  async _loadPage(t = 1) {
+    return this.setPage(t), await this._loadList(!1), this._awaitResponse();
   }
   async _awaitResponse() {
-    const e = Object.values(this.navigationEmojis), t = (t, i) => {
-      const s = !!this._enabled("ALL") && (!this._disabledNavigationEmojiValues.length || this._disabledNavigationEmojiValues.some(e => ![ t.emoji.name, t.emoji.id ].includes(e))) && (e.includes(t.emoji.name) || e.includes(t.emoji.id)) || t.emoji.name in this.functionEmojis || t.emoji.id in this.functionEmojis;
+    const t = Object.values(this.navigationEmojis), e = (e, i) => {
+      const s = !!this._enabled("ALL") && (!this._disabledNavigationEmojiValues.length || this._disabledNavigationEmojiValues.some(t => ![ e.emoji.name, e.emoji.id ].includes(t))) && (t.includes(e.emoji.name) || t.includes(e.emoji.id)) || e.emoji.name in this.functionEmojis || e.emoji.id in this.functionEmojis;
       return this.authorizedUsers.length ? this.authorizedUsers.includes(i.id) && s : !i.bot && s;
     }, i = this.clientAssets.message;
     try {
-      const e = (await i.awaitReactions(t, {
+      const t = (await i.awaitReactions(e, {
         max: 1,
         time: this.timeout,
         errors: [ "time" ]
-      })).first(), s = e.users.last(), a = [ e.emoji.name, e.emoji.id ];
-      switch (this.emit("react", s, e.emoji), i.guild && await e.users.remove(s), a[0] || a[1]) {
+      })).first(), s = t.users.last(), n = [ t.emoji.name, t.emoji.id ];
+      switch (this.listenerCount("react") && this.emit("react", s, t.emoji), i.guild && await t.users.remove(s), 
+      n[0] || n[1]) {
        case this.navigationEmojis.back:
         return 1 === this.page ? this._awaitResponse() : this._loadPage("back");
 
@@ -160,33 +163,43 @@ exports.PaginationEmbed = class extends e.EventEmitter {
         return this.page === this.pages ? this._awaitResponse() : this._loadPage("forward");
 
        case this.navigationEmojis.delete:
-        return this.emit("finish", s), i.delete();
+        return await i.delete(), void (this.listenerCount("finish") && this.emit("finish", s));
 
        default:
-        const t = this.functionEmojis[a[0]] || this.functionEmojis[a[1]];
-        return await t(s, this), this._loadPage(this.page);
+        const e = this.functionEmojis[n[0]] || this.functionEmojis[n[1]];
+        try {
+          await e(s, this);
+        } catch (t) {
+          return this._cleanUp(t, i, !1, s);
+        }
+        return this._loadPage(this.page);
       }
-    } catch (e) {
-      return i.guild && !i.deleted && await i.reactions.removeAll(), this.deleteOnTimeout && i.deletable && await i.delete(), 
-      e instanceof Error ? this.emit("error", e) : (this.emit("expire"), !0);
+    } catch (t) {
+      return this._cleanUp(t, i);
     }
   }
-  async _awaitResponseEx(e) {
-    const i = [ "0", "cancel" ], s = t => {
-      const s = parseInt(t.content);
-      return t.author.id === e.id && (!isNaN(Number(t.content)) && s !== this.page && s >= 1 && s <= this.pages || i.includes(t.content.toLowerCase()));
-    }, a = this.clientAssets.message.channel, n = await a.send(this.clientAssets.prompt.replace(/\{\{user\}\}/g, e.toString()));
+  async _cleanUp(t, e, i = !0, s) {
+    if (this.deleteOnTimeout && e.deletable && await e.delete(), e.guild && !e.deleted && await e.reactions.removeAll(), 
+    t instanceof Error) return void (this.listenerCount("error") && this.emit("error", t));
+    const n = i ? "expire" : "finish";
+    this.listenerCount(n) && this.emit(n, s);
+  }
+  async _awaitResponseEx(t) {
+    const i = [ "0", "cancel" ], s = e => {
+      const s = parseInt(e.content);
+      return e.author.id === t.id && (!isNaN(Number(e.content)) && s !== this.page && s >= 1 && s <= this.pages || i.includes(e.content.toLowerCase()));
+    }, n = this.clientAssets.message.channel, a = await n.send(this.clientAssets.prompt.replace(/\{\{user\}\}/g, t.toString()));
     try {
-      const e = (await a.awaitMessages(s, {
+      const t = (await n.awaitMessages(s, {
         max: 1,
         time: this.timeout,
         errors: [ "time" ]
-      })).first(), o = e.content;
-      return this.clientAssets.message.deleted ? this.emit("error", new Error(t)) : (await n.delete(), 
-      e.deletable && await e.delete(), i.includes(o) ? this._awaitResponse() : this._loadPage(parseInt(o)));
-    } catch (e) {
-      return n.deletable && await n.delete(), e instanceof Error ? this.emit("error", e) : (this.emit("expire"), 
-      !0);
+      })).first(), o = t.content;
+      return this.clientAssets.message.deleted ? void (this.listenerCount("error") && this.emit("error", new Error(e))) : (await a.delete(), 
+      t.deletable && await t.delete(), i.includes(o) ? this._awaitResponse() : this._loadPage(parseInt(o)));
+    } catch (t) {
+      if (a.deletable && await a.delete(), t instanceof Error) return void (this.listenerCount("error") && this.emit("error", t));
+      this.listenerCount("expire") && this.emit("expire");
     }
   }
 };

--- a/deploy/travis.sh
+++ b/deploy/travis.sh
@@ -5,7 +5,7 @@ set -e
 
 if [ "$TRAVIS_BRANCH" != "master" -o -n "$TRAVIS_TAG" -o "$TRAVIS_PULL_REQUEST" != "false" ]; then
   echo -e "Not building for a non master branch push - building without deploying."
-  yarn run gh:build
+  yarn gh:build
   exit 0
 fi
 
@@ -17,13 +17,13 @@ SHA=$(git rev-parse --verify HEAD)
 TARGET_BRANCH="gh-pages"
 git clone $REPO dist -b $TARGET_BRANCH
 
-yarn run gh:build
+yarn gh:build
 
-rsync -vau docs/ dist/
+rsync --delete-before --exclude='.git' --exclude='.nojekyll' -avh docs/ dist/
 
 cd dist
 git add --all .
 git config user.name "Travis CI"
 git config user.email "${COMMIT_EMAIL}"
-git commit -m "Docs build: ${SHA}" || true
+git commit -m "Build: ${SHA}" || true
 git push "https://${GITHUB_TOKEN}@github.com/gazmull/discord-paginationembed.git" $TARGET_BRANCH

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "discord-paginationembed",
-  "version": "1.0.0-beta.3",
+  "version": "1.0.0-beta.4",
   "description": "A pagination utility for MessageEmbed in Discord.JS",
   "main": "./bin/index.js",
   "types": "./typings",

--- a/package.json
+++ b/package.json
@@ -54,8 +54,5 @@
     "typedoc": "^0.14.2",
     "typedoc-plugin-no-inherit": "^1.1.6",
     "typescript": "^3.4.5"
-  },
-  "dependencies": {
-    "discord.js": "github:discordjs/discord.js"
   }
 }

--- a/package.json
+++ b/package.json
@@ -43,16 +43,19 @@
     "discord.js": "github:discordjs/discord.js"
   },
   "devDependencies": {
-    "@types/node": "^11.11.6",
-    "del": "^4.0.0",
-    "gulp": "^4.0.0",
+    "@types/node": "^11.13.7",
+    "del": "^4.1.0",
+    "gulp": "^4.0.1",
     "gulp-terser": "^1.1.7",
     "gulp-tslint": "^8.1.4",
     "gulp-typescript": "^5.0.1",
-    "tslint": "5.14.0",
+    "tslint": "^5.16.0",
     "tslint-eslint-rules": "^5.4.0",
     "typedoc": "^0.14.2",
     "typedoc-plugin-no-inherit": "^1.1.6",
-    "typescript": "^3.3.4000"
+    "typescript": "^3.4.5"
+  },
+  "dependencies": {
+    "discord.js": "github:discordjs/discord.js"
   }
 }

--- a/src/Embeds.ts
+++ b/src/Embeds.ts
@@ -1,4 +1,4 @@
-import { ColorResolvable, EmbedField, MessageEmbed, StringResolvable } from 'discord.js';
+import { ColorResolvable, EmbedField, Message, MessageEmbed, StringResolvable } from 'discord.js';
 import { PaginationEmbed } from './base';
 
 /**
@@ -96,7 +96,7 @@ export class Embeds extends PaginationEmbed<MessageEmbed> {
    *   new Embeds()
    *    .setAuthorizedUsers([message.author.id])
    *    .setChannel(message.channel)
-   *    .setClientAssets({ prepare: 'Preparing the embed...' })
+   *    .setClientAssets({ prompt: 'Yo {{user}} wat peige?!?!?' })
    *    .setArray(embeds)
    *    .setPageIndicator(false)
    *    .setPage(1)
@@ -126,7 +126,8 @@ export class Embeds extends PaginationEmbed<MessageEmbed> {
     this.pages = this.array.length;
 
     await this._verify();
-    this.emit('start');
+
+    if (this.listenerCount('start')) this.emit('start');
 
     return this._loadList();
   }
@@ -309,7 +310,10 @@ export class Embeds extends PaginationEmbed<MessageEmbed> {
         : `Page ${this.page} of ${this.pages}`
       : null;
 
-    await this.clientAssets.message.edit(shouldIndicate, { embed: this.currentEmbed });
+    if (this.clientAssets.message)
+      await this.clientAssets.message.edit(shouldIndicate, { embed: this.currentEmbed });
+    else
+      this.clientAssets.message = await this.channel.send(shouldIndicate, { embed: this.currentEmbed }) as Message;
 
     return super._loadList(callNavigation);
   }

--- a/src/Embeds.ts
+++ b/src/Embeds.ts
@@ -52,7 +52,7 @@ export class Embeds extends PaginationEmbed<MessageEmbed> {
 
   /**
    * Adds a blank field to the fields of all embeds.
-   * @param inline - Whether the field is inline or not to the other fields.
+   * @param inline - Whether the field is inline to the other fields.
    */
   public addBlankField (inline = false) {
     if (!this.array) throw new TypeError('this.array must be set first.');
@@ -67,7 +67,7 @@ export class Embeds extends PaginationEmbed<MessageEmbed> {
    * Adds a field to the fields of all embeds.
    * @param name - The name of the field.
    * @param value - The value of the field.
-   * @param inline - Whether the field is inline or not to the other fields.
+   * @param inline - Whether the field is inline to the other fields.
    */
   public addField (name: string, value: StringResolvable, inline = false) {
     if (!this.array) throw new TypeError('this.array must be set first.');

--- a/src/FieldsEmbed.ts
+++ b/src/FieldsEmbed.ts
@@ -102,7 +102,7 @@ export class FieldsEmbed<Element> extends PaginationEmbed<Element> {
    * Same as MessageEmbed.addField, but value takes a function instead.
    * @param name - Name of the field.
    * @param value - Value of the field. Function for `Array.prototype.map().join('\n')`.
-   * @param inline - Whether the field is inline with other field or not. Default: `true`
+   * @param inline - Whether the field is inline with other field. Default: `true`
    */
   public formatField (name: string, value: (element: Element) => any, inline = true) {
     if (typeof value !== 'function') throw new TypeError('formatField() value parameter only takes a function.');

--- a/src/FieldsEmbed.ts
+++ b/src/FieldsEmbed.ts
@@ -1,4 +1,4 @@
-import { MessageEmbed } from 'discord.js';
+import { Message, MessageEmbed } from 'discord.js';
 import { PaginationEmbed } from './base';
 
 /**
@@ -48,7 +48,7 @@ export class FieldsEmbed<Element> extends PaginationEmbed<Element> {
    *   new FieldsEmbed()
    *    .setAuthorizedUsers([message.author.id])
    *    .setChannel(message.channel)
-   *    .setClientAssets({ prepare: 'Preparing the embed...' })
+   *    .setClientAssets({ prompt: 'Yo {{user}} wat peige?!?!?' })
    *    .setArray([{ name: 'John Doe' }, { name: 'Jane Doe' }])
    *    .setElementsPerPage(1)
    *    .setPageIndicator(false)
@@ -92,7 +92,7 @@ export class FieldsEmbed<Element> extends PaginationEmbed<Element> {
     if (!hasPaginateField)
       throw new Error('Cannot invoke FieldsEmbed class without at least one formatted field to paginate.');
 
-    this.emit('start');
+    if (this.listenerCount('start')) this.emit('start');
 
     return this._loadList();
   }
@@ -150,7 +150,10 @@ export class FieldsEmbed<Element> extends PaginationEmbed<Element> {
         : `Page ${this.page} of ${this.pages}`
       : null;
 
-    await this.clientAssets.message.edit(shouldIndicate, { embed });
+    if (this.clientAssets.message)
+      await this.clientAssets.message.edit(shouldIndicate, { embed });
+    else
+      this.clientAssets.message = await this.channel.send(shouldIndicate, { embed }) as Message;
 
     return super._loadList(callNavigation);
   }

--- a/src/base/index.ts
+++ b/src/base/index.ts
@@ -3,6 +3,7 @@ import { EventEmitter } from 'events';
 import { Embeds } from '../Embeds';
 import { FieldsEmbed } from '../FieldsEmbed';
 
+/** @ignore */
 const MESSAGE_DELETED = 'Client\'s message was deleted before being processed.';
 
 /**

--- a/src/base/index.ts
+++ b/src/base/index.ts
@@ -194,13 +194,12 @@ export class PaginationEmbed<Element> extends EventEmitter {
     if (!assets) throw new TypeError('Cannot accept assets options as a non-object type.');
 
     const { message } = assets;
-    let { prepare, prompt } = assets;
+    let { prompt } = assets;
 
-    if (!prepare) prepare = 'Preparing...';
     if (!prompt)
       prompt = '{{user}}, To what page would you like to jump? Say `cancel` or `0` to cancel the prompt.';
 
-    Object.assign(this.clientAssets, { message, prepare, prompt });
+    Object.assign(this.clientAssets, { message, prompt });
 
     return this;
   }
@@ -363,20 +362,25 @@ export class PaginationEmbed<Element> extends EventEmitter {
   public async _verify () {
     this.setClientAssets(this.clientAssets);
 
-    if (!this.clientAssets.message && !this.channel)
-      throw new Error('Cannot invoke PaginationEmbed class without either a message object or a channel object set.');
+    if (!this.channel)
+      throw new Error('Cannot invoke PaginationEmbed class without a channel object set.');
 
     if (!(this.page >= 1 && this.page <= this.pages))
-      throw new Error(`Page number is out of bounds. Max pages: ${this.pages}`);
+      throw new RangeError(`Page number is out of bounds. Max pages: ${this.pages}`);
 
-    const message = (this.clientAssets.message
-      ? await this.clientAssets.message.edit(this.clientAssets.prepare)
-      : await this.channel.send(this.clientAssets.prepare)) as Message;
-    this.clientAssets.message = message;
+    return this._checkPermissions();
+  }
 
-    if (message.guild) {
-      const missing = (message.channel as TextChannel)
-        .permissionsFor(message.client.user)
+  /**
+   * Checks the permissions of the client before sending the embed.
+   * @ignore
+   */
+  public async _checkPermissions () {
+    const channel = this.channel as TextChannel;
+
+    if (channel.guild) {
+      const missing = channel
+        .permissionsFor(channel.client.user)
         .missing([ 'ADD_REACTIONS', 'MANAGE_MESSAGES', 'EMBED_LINKS', 'VIEW_CHANNEL', 'SEND_MESSAGES' ]);
 
       if (missing.length)
@@ -436,7 +440,7 @@ export class PaginationEmbed<Element> extends EventEmitter {
   }
 
   /** Awaits the reaction from the user. */
-  protected async _awaitResponse () {
+  protected async _awaitResponse (): Promise<void> {
     const emojis = Object.values(this.navigationEmojis);
     const filter = (r: MessageReaction, u: User) => {
       const enabledEmoji = this._enabled('ALL')
@@ -460,8 +464,7 @@ export class PaginationEmbed<Element> extends EventEmitter {
       const user = response.users.last();
       const emoji = [ response.emoji.name, response.emoji.id ];
 
-      this.emit('react', user, response.emoji);
-
+      if (this.listenerCount('react')) this.emit('react', user, response.emoji);
       if (clientMessage.guild) await response.users.remove(user);
 
       switch (emoji[0] || emoji[1]) {
@@ -481,26 +484,48 @@ export class PaginationEmbed<Element> extends EventEmitter {
           return this._loadPage('forward');
 
         case this.navigationEmojis.delete:
-          this.emit('finish', user);
+          await clientMessage.delete();
 
-          return clientMessage.delete();
+          if (this.listenerCount('finish')) this.emit('finish', user);
+
+          return;
 
         default:
           const cb = this.functionEmojis[emoji[0]] || this.functionEmojis[emoji[1]];
 
-          await cb(user, this as unknown as Embeds | FieldsEmbed<Element>);
+          try {
+            await cb(user, this as unknown as Embeds | FieldsEmbed<Element>);
+          } catch (err) {
+            return this._cleanUp(err, clientMessage, false, user);
+          }
 
           return this._loadPage(this.page);
       }
-    } catch (c) {
-      if (clientMessage.guild && !clientMessage.deleted) await clientMessage.reactions.removeAll();
-      if (this.deleteOnTimeout && clientMessage.deletable) await clientMessage.delete();
-      if (c instanceof Error) return this.emit('error', c);
-
-      this.emit('expire');
-
-      return true;
+    } catch (err) {
+      return this._cleanUp(err, clientMessage);
     }
+  }
+
+  /**
+   * Only used for _awaitResponse:
+   * Deletes the client's message, and emites either error or finish depending on the passed parameters.
+   * @param err The error object.
+   * @param clientMessage The client's message.
+   * @param expired Whether the clean up is for `expired` event.
+   * @param user The user object (only for `finish` event).
+   */
+  protected async _cleanUp (err: any, clientMessage: Message, expired = true, user?: User) {
+    if (this.deleteOnTimeout && clientMessage.deletable) await clientMessage.delete();
+    if (clientMessage.guild && !clientMessage.deleted) await clientMessage.reactions.removeAll();
+    if (err instanceof Error) {
+      if (this.listenerCount('error')) this.emit('error', err);
+
+      return;
+    }
+
+    const eventType = expired ? 'expire' : 'finish';
+
+    if (this.listenerCount(eventType)) this.emit(eventType, user);
   }
 
   /**
@@ -528,8 +553,11 @@ export class PaginationEmbed<Element> extends EventEmitter {
       const response = responses.first();
       const content = response.content;
 
-      if (this.clientAssets.message.deleted)
-        return this.emit('error', new Error(MESSAGE_DELETED));
+      if (this.clientAssets.message.deleted) {
+        if (this.listenerCount('error')) this.emit('error', new Error(MESSAGE_DELETED));
+
+        return;
+      }
 
       await prompt.delete();
       if (response.deletable) await response.delete();
@@ -538,11 +566,13 @@ export class PaginationEmbed<Element> extends EventEmitter {
       return this._loadPage(parseInt(content));
     } catch (c) {
       if (prompt.deletable) await prompt.delete();
-      if (c instanceof Error) return this.emit('error', c);
+      if (c instanceof Error) {
+        if (this.listenerCount('error')) this.emit('error', c);
 
-      this.emit('expire');
+        return;
+      }
 
-      return true;
+      if (this.listenerCount('expire')) this.emit('expire');
     }
   }
 
@@ -616,8 +646,6 @@ export interface INavigationEmojis {
 export interface IClientAssets {
   /** The message object. */
   message?: Message;
-  /** The text during initialisation of the pagination. Default: `"Preparing..."` */
-  prepare?: string;
   /**
    * The text during a prompt for page jump.
    *

--- a/test/bot.js
+++ b/test/bot.js
@@ -30,6 +30,7 @@ bot
       test,
       users,
       disabledNavigationEmojis,
+      emojisFunctionAfterNavigation,
       deleteOnTimeout
     } = credentials;
 
@@ -52,6 +53,7 @@ bot
         .setURL('https://gazmull.github.io/discord-paginationembed')
         .setColor(0xFF00AE)
         .setDeleteOnTimeout(deleteOnTimeout)
+        .setEmojisFunctionAfterNavigation(emojisFunctionAfterNavigation)
         .setDisabledNavigationEmojis(disabledNavigationEmojis)
         .setFunctionEmojis({
           '⬆': (_, instance) => {
@@ -85,6 +87,7 @@ bot
         .formatField('Name', i => i.name)
         .setDeleteOnTimeout(deleteOnTimeout)
         .setDisabledNavigationEmojis(disabledNavigationEmojis)
+        .setEmojisFunctionAfterNavigation(emojisFunctionAfterNavigation)
         .setFunctionEmojis({
           '🔄': (user, instance) => {
             const field = instance.embed.fields[0];

--- a/test/bot.js
+++ b/test/bot.js
@@ -33,6 +33,8 @@ bot
       deleteOnTimeout
     } = credentials;
 
+    console.log('Mode:', test);
+
     if (test === 'embeds') {
       const embeds = [];
 
@@ -59,7 +61,8 @@ bot
           '⬇': (_, instance) => {
             for (const embed of instance.array)
               embed.fields[0].value--;
-          }
+          },
+          '⏹': () => Promise.reject('stopped')
         })
         .setClientAssets({ prompt: 'yAAAaA— what page {{user}}?' })
         .on('start', () => console.log('Started!'))

--- a/test/credentials.sample.js
+++ b/test/credentials.sample.js
@@ -4,5 +4,6 @@ module.exports = {
   users: [], // Users authorized to interact with the utility
   test: 'embeds', // 'embeds' or 'fieldsembed' to test
   disabledNavigationEmojis: ['delete'], // 'ALL' / 'BACK' / 'JUMP' / 'FOWARD' / 'DELETE',
+  emojisFunctionAfterNavigation: false, // Whether function emojis should be deployed after navigation emojis
   deleteOnTimeout: true // Delete PaginationEmbed message after awaiting response timeout?
 };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,8 @@
     "noUnusedLocals": true,
     "outDir": "bin",
     "removeComments": false,
-    "target": "es2018"
+    "incremental": true,
+    "target": "es2017"
   },
   "include": [
     "src"

--- a/typedoc.json
+++ b/typedoc.json
@@ -1,9 +1,10 @@
 {
   "excludeExternals": true,
+  "excludeProtected": true,
   "includeDeclarations": true,
   "mode": "file",
   "name": "Discord PaginationEmbed - Docs",
   "out": "docs",
   "readme": "README.md",
-  "theme": "minimal"
+  "theme": "default"
 }

--- a/typings/Embeds.d.ts
+++ b/typings/Embeds.d.ts
@@ -37,14 +37,14 @@ export declare class Embeds extends PaginationEmbed<MessageEmbed> {
     readonly currentEmbed: MessageEmbed;
     /**
      * Adds a blank field to the fields of all embeds.
-     * @param inline - Whether the field is inline or not to the other fields.
+     * @param inline - Whether the field is inline to the other fields.
      */
     addBlankField(inline?: boolean): this;
     /**
      * Adds a field to the fields of all embeds.
      * @param name - The name of the field.
      * @param value - The value of the field.
-     * @param inline - Whether the field is inline or not to the other fields.
+     * @param inline - Whether the field is inline to the other fields.
      */
     addField(name: string, value: StringResolvable, inline?: boolean): this;
     /**

--- a/typings/Embeds.d.ts
+++ b/typings/Embeds.d.ts
@@ -64,7 +64,7 @@ export declare class Embeds extends PaginationEmbed<MessageEmbed> {
      *   new Embeds()
      *    .setAuthorizedUsers([message.author.id])
      *    .setChannel(message.channel)
-     *    .setClientAssets({ prepare: 'Preparing the embed...' })
+     *    .setClientAssets({ prompt: 'Yo {{user}} wat peige?!?!?' })
      *    .setArray(embeds)
      *    .setPageIndicator(false)
      *    .setPage(1)
@@ -90,7 +90,7 @@ export declare class Embeds extends PaginationEmbed<MessageEmbed> {
      *    .setTimestamp()
      *    .build();```
      */
-    build(): Promise<any>;
+    build(): Promise<void>;
     /**
      * Sets the array of MessageEmbed to paginate.
      * @param array - An array of MessageEmbed to paginate.
@@ -154,5 +154,5 @@ export declare class Embeds extends PaginationEmbed<MessageEmbed> {
      */
     spliceField(index: number, deleteCount: number, name?: StringResolvable, value?: StringResolvable, inline?: boolean): this;
     /** @ignore */
-    _loadList(callNavigation?: boolean): Promise<any>;
+    _loadList(callNavigation?: boolean): Promise<void>;
 }

--- a/typings/FieldsEmbed.d.ts
+++ b/typings/FieldsEmbed.d.ts
@@ -32,7 +32,7 @@ export declare class FieldsEmbed<Element> extends PaginationEmbed<Element> {
      *   new FieldsEmbed()
      *    .setAuthorizedUsers([message.author.id])
      *    .setChannel(message.channel)
-     *    .setClientAssets({ prepare: 'Preparing the embed...' })
+     *    .setClientAssets({ prompt: 'Yo {{user}} wat peige?!?!?' })
      *    .setArray([{ name: 'John Doe' }, { name: 'Jane Doe' }])
      *    .setElementsPerPage(1)
      *    .setPageIndicator(false)
@@ -57,7 +57,7 @@ export declare class FieldsEmbed<Element> extends PaginationEmbed<Element> {
      *    })
      *    .build();```
      */
-    build(): Promise<any>;
+    build(): Promise<void>;
     /**
      * Adds a field to the embed.
      * Same as MessageEmbed.addField, but value takes a function instead.
@@ -73,5 +73,5 @@ export declare class FieldsEmbed<Element> extends PaginationEmbed<Element> {
     setElementsPerPage(max: number): this;
     protected _drawList(): Promise<MessageEmbed>;
     /** @ignore */
-    _loadList(callNavigation?: boolean): Promise<any>;
+    _loadList(callNavigation?: boolean): Promise<void>;
 }

--- a/typings/FieldsEmbed.d.ts
+++ b/typings/FieldsEmbed.d.ts
@@ -63,7 +63,7 @@ export declare class FieldsEmbed<Element> extends PaginationEmbed<Element> {
      * Same as MessageEmbed.addField, but value takes a function instead.
      * @param name - Name of the field.
      * @param value - Value of the field. Function for `Array.prototype.map().join('\n')`.
-     * @param inline - Whether the field is inline with other field or not. Default: `true`
+     * @param inline - Whether the field is inline with other field. Default: `true`
      */
     formatField(name: string, value: (element: Element) => any, inline?: boolean): this;
     /**

--- a/typings/base/index.d.ts
+++ b/typings/base/index.d.ts
@@ -18,9 +18,9 @@ export declare class PaginationEmbed<Element> extends EventEmitter {
     clientAssets: IClientAssets;
     /** An array of elements to paginate. */
     array: Element[];
-    /** Whether page number indicator on client's message is shown or not. Default: `true` */
+    /** Whether page number indicator on client's message is shown. Default: `true` */
     pageIndicator: boolean;
-    /**  Whether the client's message will be deleted upon timeout or not. Default: `false` */
+    /**  Whether the client's message will be deleted upon timeout. Default: `false` */
     deleteOnTimeout: boolean;
     /** Jumps to a certain page upon PaginationEmbed.build(). Default: `1` */
     page: number;
@@ -40,6 +40,8 @@ export declare class PaginationEmbed<Element> extends EventEmitter {
      * - 'ALL'
      */
     disabledNavigationEmojis: Array<'BACK' | 'JUMP' | 'FORWARD' | 'DELETE' | 'ALL'>;
+    /** Whether to set function emojis after navigation emojis. Default: `false` */
+    emojisFunctionAfterNavigation: boolean;
     /**
      * Number of pages for this instance.
      * @ignore
@@ -116,6 +118,11 @@ export declare class PaginationEmbed<Element> extends EventEmitter {
      */
     setDisabledNavigationEmojis(emojis: DisabledNavigationEmojis): this;
     /**
+     * Sets whether to set function emojis after navigation emojis.
+     * @param boolean - Set function emojis after navigation emojis?
+     */
+    setEmojisFunctionAfterNavigation(boolean: boolean): this;
+    /**
      * Sets the emojis used for function emojis.
      *
      * ### Example
@@ -150,12 +157,12 @@ export declare class PaginationEmbed<Element> extends EventEmitter {
      */
     setTimeout(timeout: number): this;
     /**
-     * Sets whether page number indicator on client's message is shown or not.
+     * Sets whether page number indicator on client's message is shown.
      * @param indicator - Show page indicator?
      */
     setPageIndicator(boolean: boolean): this;
     /**
-     * Sets whether the client's message will be deleted upon timeout or not.
+     * Sets whether the client's message will be deleted upon timeout.
      * @param deleteOnTimeout - Delete client's message upon timeout?
      */
     setDeleteOnTimeout(boolean: boolean): this;
@@ -170,16 +177,20 @@ export declare class PaginationEmbed<Element> extends EventEmitter {
      */
     _checkPermissions(): Promise<boolean>;
     /**
-     * Returns whether the given navigation emoji is enabled or not.
+     * Returns whether the given navigation emoji is enabled.
      * @param emoji The navigation emoji to search.
      */
     protected _enabled(emoji: NavigationEmojiIdentifier): boolean;
     /** Deploys emoji reacts for the message sent by the client. */
-    protected _drawNavigation(): Promise<void>;
+    protected _drawEmojis(): Promise<void>;
+    /** Deploys function emojis. */
+    protected _drawFunctionEmojis(): Promise<void>;
+    /** Deploys navigation emojis. */
+    protected _drawNavigationEmojis(): Promise<void>;
     /**
      * Helper for intialising the MessageEmbed.
      * [For sub-class] Initialises the MessageEmbed.
-     * @param callNavigation - Whether to call _drawNavigation() or not.
+     * @param callNavigation - Whether to call _drawEmojis().
      * @ignore
      */
     _loadList(callNavigation?: boolean): Promise<void>;
@@ -188,7 +199,7 @@ export declare class PaginationEmbed<Element> extends EventEmitter {
      * @param param - The page number to jump to.
      */
     protected _loadPage(param?: number | 'back' | 'forward'): Promise<void>;
-    /** Awaits the reaction from the user. */
+    /** Awaits the reaction from the user(s). */
     protected _awaitResponse(): Promise<void>;
     /**
      * Only used for _awaitResponse:

--- a/typings/base/index.d.ts
+++ b/typings/base/index.d.ts
@@ -165,31 +165,45 @@ export declare class PaginationEmbed<Element> extends EventEmitter {
      */
     _verify(): Promise<boolean>;
     /**
+     * Checks the permissions of the client before sending the embed.
+     * @ignore
+     */
+    _checkPermissions(): Promise<boolean>;
+    /**
      * Returns whether the given navigation emoji is enabled or not.
      * @param emoji The navigation emoji to search.
      */
     protected _enabled(emoji: NavigationEmojiIdentifier): boolean;
     /** Deploys emoji reacts for the message sent by the client. */
-    protected _drawNavigation(): Promise<any>;
+    protected _drawNavigation(): Promise<void>;
     /**
      * Helper for intialising the MessageEmbed.
      * [For sub-class] Initialises the MessageEmbed.
      * @param callNavigation - Whether to call _drawNavigation() or not.
      * @ignore
      */
-    _loadList(callNavigation?: boolean): Promise<any>;
+    _loadList(callNavigation?: boolean): Promise<void>;
     /**
      * Calls PaginationEmbed.setPage() and then executes `_loadList()` and `_awaitResponse()`.
      * @param param - The page number to jump to.
      */
-    protected _loadPage(param?: number | 'back' | 'forward'): any;
+    protected _loadPage(param?: number | 'back' | 'forward'): Promise<void>;
     /** Awaits the reaction from the user. */
-    protected _awaitResponse(): any;
+    protected _awaitResponse(): Promise<void>;
+    /**
+     * Only used for _awaitResponse:
+     * Deletes the client's message, and emites either error or finish depending on the passed parameters.
+     * @param err The error object.
+     * @param clientMessage The client's message.
+     * @param expired Whether the clean up is for `expired` event.
+     * @param user The user object (only for `finish` event).
+     */
+    protected _cleanUp(err: any, clientMessage: Message, expired?: boolean, user?: User): Promise<void>;
     /**
      * Awaits the custom page input from the user.
      * @param user - The user who reacted to jump on a certain page.
      */
-    protected _awaitResponseEx(user: User): any;
+    protected _awaitResponseEx(user: User): Promise<void>;
     /**
      * Emitted upon successful `build()`.
      * @event
@@ -246,8 +260,6 @@ export interface INavigationEmojis {
 export interface IClientAssets {
     /** The message object. */
     message?: Message;
-    /** The text during initialisation of the pagination. Default: `"Preparing..."` */
-    prepare?: string;
     /**
      * The text during a prompt for page jump.
      *


### PR DESCRIPTION
[**Updating from `v0.8.0`**](https://github.com/gazmull/discord-paginationembed/blob/1.0.0-beta.4/UPDATING_V1.md#api-changes) (Updated, please read again)

## Added
- Added ability to stop the instance from awaiting emoji reacts with function emojis:
    ```js
    <PaginationEmbed>.addFunctionEmoji('🛑', () => {
        // Either
        throw 'stopped';

        // or
        return Promise.reject('stopped');

        // will stop the instance from awaiting reacts.
        // Passing an error object will emit the `error` event.
    });
    ```
- Added `PaginationEmbed#setEmojisFunctionAfterNavigation` method. This allows function emojis to either be the first/last set to be deployed before/after navigation emojis.
  -  Default: `false`.

## Changed
- PaginationEmbed no longer emits an event when there is no listener (invoking `.on`/`.once`)

## Removed
- Option `prepare` for `clientAssets` has been removed. This affects:
    - Setting the `channel` property is a must now. (Used to be either `clientAssets.message` or `channel` must be set)

## Fixed
- Fixed possibly unnecessary API call on awaiting emoji reacts timeout.
  - `clientMessage#delete` now precedes `clientMessage.reactions#removeAll`