### PR TITLE
Fix for the "start"-event getting emitted before the embed is sent

### DIFF
--- a/bin/Embeds.js
+++ b/bin/Embeds.js
@@ -102,7 +102,7 @@ class s extends t.PaginationEmbed {
       embed: this.currentEmbed
     }) : this.clientAssets.message = await this.channel.send(t, {
       embed: this.currentEmbed
-    }), this.listenerCount("start") && this.emit("start"), super._loadList(r);
+    }), super._loadList(r);
   }
   _buildIndicator() {
     if (!this.circleIndicator) return `Page ${this.page} of ${this.pages}`;

--- a/bin/Embeds.js
+++ b/bin/Embeds.js
@@ -28,8 +28,7 @@ class s extends t.PaginationEmbed {
     return this;
   }
   async build() {
-    return this.pages = this.array.length, await this._verify(), this.listenerCount("start") && this.emit("start"), 
-    this._loadList();
+    return this.pages = this.array.length, await this._verify(), this._loadList();
   }
   setArray(t) {
     if (!(Array.isArray(t) && Boolean(t.length))) throw new TypeError("Cannot invoke Embeds class without a valid array to paginate.");
@@ -103,7 +102,7 @@ class s extends t.PaginationEmbed {
       embed: this.currentEmbed
     }) : this.clientAssets.message = await this.channel.send(t, {
       embed: this.currentEmbed
-    }), super._loadList(r);
+    }), this.listenerCount("start") && this.emit("start"), super._loadList(r);
   }
   _buildIndicator() {
     if (!this.circleIndicator) return `Page ${this.page} of ${this.pages}`;

--- a/bin/FieldsEmbed.js
+++ b/bin/FieldsEmbed.js
@@ -20,7 +20,7 @@ class s extends t.PaginationEmbed {
     this.embed.fields = [];
     for (const t of e) "function" == typeof t.value ? this.formatField(t.name, t.value, t.inline) : this.embed.addField(t.name, t.value, t.inline);
     if (!this.embed.fields.filter(e => "function" == typeof e.value).length) throw new Error("Cannot invoke FieldsEmbed class without at least one formatted field to paginate.");
-    return this.listenerCount("start") && this.emit("start"), this._loadList();
+    return this._loadList();
   }
   formatField(e, t, s = !0) {
     if ("function" != typeof t) throw new TypeError("formatField() value parameter only takes a function.");
@@ -46,7 +46,7 @@ class s extends t.PaginationEmbed {
       embed: t
     }) : this.clientAssets.message = await this.channel.send(s, {
       embed: t
-    }), super._loadList(e);
+    }), this.listenerCount("start") && this.emit("start"), super._loadList(e);
   }
   _buildIndicator() {
     if (!this.circleIndicator) return `Page ${this.page} of ${this.pages}`;

--- a/bin/FieldsEmbed.js
+++ b/bin/FieldsEmbed.js
@@ -46,7 +46,7 @@ class s extends t.PaginationEmbed {
       embed: t
     }) : this.clientAssets.message = await this.channel.send(s, {
       embed: t
-    }), this.listenerCount("start") && this.emit("start"), super._loadList(e);
+    }), super._loadList(e);
   }
   _buildIndicator() {
     if (!this.circleIndicator) return `Page ${this.page} of ${this.pages}`;

--- a/bin/base/index.js
+++ b/bin/base/index.js
@@ -136,7 +136,7 @@ class e extends t.EventEmitter {
   async _drawEmojis() {
     return this.emojisFunctionAfterNavigation ? (await this._drawNavigationEmojis(), 
     await this._drawFunctionEmojis()) : (await this._drawFunctionEmojis(), await this._drawNavigationEmojis()), 
-    this._awaitResponse();
+    this.listenerCount("start") && this.emit("start"), this._awaitResponse();
   }
   async _drawFunctionEmojis() {
     if (Object.keys(this.functionEmojis).length) for (const t of Object.keys(this.functionEmojis)) await this.clientAssets.message.react(t);

--- a/src/Embeds.ts
+++ b/src/Embeds.ts
@@ -334,9 +334,6 @@ export class Embeds extends PaginationEmbed<MessageEmbed> {
       await this.clientAssets.message.edit(shouldIndicate, { embed: this.currentEmbed });
     else
       this.clientAssets.message = await this.channel.send(shouldIndicate, { embed: this.currentEmbed }) as Message;
-    if (this.listenerCount("start")) {
-      this.emit("start");
-    }
     return super._loadList(callNavigation);
   }
   

--- a/src/Embeds.ts
+++ b/src/Embeds.ts
@@ -149,8 +149,6 @@ export class Embeds extends PaginationEmbed<MessageEmbed> {
 
     await this._verify();
 
-    if (this.listenerCount('start')) this.emit('start');
-
     return this._loadList();
   }
 
@@ -336,7 +334,9 @@ export class Embeds extends PaginationEmbed<MessageEmbed> {
       await this.clientAssets.message.edit(shouldIndicate, { embed: this.currentEmbed });
     else
       this.clientAssets.message = await this.channel.send(shouldIndicate, { embed: this.currentEmbed }) as Message;
-
+    if (this.listenerCount("start")) {
+      this.emit("start");
+    }
     return super._loadList(callNavigation);
   }
   

--- a/src/FieldsEmbed.ts
+++ b/src/FieldsEmbed.ts
@@ -152,9 +152,6 @@ export class FieldsEmbed<Element> extends PaginationEmbed<Element> {
       await this.clientAssets.message.edit(shouldIndicate, { embed });
     else
       this.clientAssets.message = await this.channel.send(shouldIndicate, { embed }) as Message;
-    if (this.listenerCount("start")) {
-      this.emit("start");
-    }
     return super._loadList(callNavigation);
   }
   

--- a/src/FieldsEmbed.ts
+++ b/src/FieldsEmbed.ts
@@ -92,8 +92,6 @@ export class FieldsEmbed<Element> extends PaginationEmbed<Element> {
     if (!hasPaginateField)
       throw new Error('Cannot invoke FieldsEmbed class without at least one formatted field to paginate.');
 
-    if (this.listenerCount('start')) this.emit('start');
-
     return this._loadList();
   }
 
@@ -154,7 +152,9 @@ export class FieldsEmbed<Element> extends PaginationEmbed<Element> {
       await this.clientAssets.message.edit(shouldIndicate, { embed });
     else
       this.clientAssets.message = await this.channel.send(shouldIndicate, { embed }) as Message;
-
+    if (this.listenerCount("start")) {
+      this.emit("start");
+    }
     return super._loadList(callNavigation);
   }
   

--- a/src/base/index.ts
+++ b/src/base/index.ts
@@ -445,6 +445,10 @@ export class PaginationEmbed<Element> extends EventEmitter {
       await this._drawNavigationEmojis();
     }
 
+    if (this.listenerCount("start")) {
+      this.emit("start");
+    }
+
     return this._awaitResponse();
   }
 


### PR DESCRIPTION
Moved the emitters (`this.emit("start")`) from `FieldsEmbed.ts` and `Embeds.ts` to `_drawEmojis()` in `index.ts`, before awaiting for emoji-reactions, so the event on `.on('start')` hook doesn't get fired before the embed is sent. 