### PR TITLE
Improved way of asking for permission to manage messages

### DIFF
--- a/bin/Embeds.js
+++ b/bin/Embeds.js
@@ -1,255 +1,106 @@
 "use strict";
-Object.defineProperty(exports, "__esModule", { value: true });
-exports.Embeds = void 0;
-const discord_js_1 = require("discord.js");
-const base_1 = require("./base");
-/**
- * A pagination mode that uses an array of MessageEmbed to paginate.
- * @extends [[PaginationEmbed]]
- * @noInheritDoc
- */
-class Embeds extends base_1.PaginationEmbed {
-    /** Embed in the current page. */
-    get currentEmbed() {
-        return this.array[this.page - 1];
+
+Object.defineProperty(exports, "__esModule", {
+  value: !0
+}), exports.Embeds = void 0;
+
+const r = require("discord.js"), t = require("./base");
+
+class s extends t.PaginationEmbed {
+  get currentEmbed() {
+    return this.array[this.page - 1];
+  }
+  addField(r, t, s = !1) {
+    if (!this.array) throw new TypeError("this.array must be set first.");
+    for (const e of this.array) e.addField(r, t, s);
+    return this;
+  }
+  addFields(...r) {
+    if (!this.array) throw new TypeError("this.array must be set first.");
+    for (const t of this.array) t.addFields(...r);
+  }
+  attachFiles(r) {
+    if (!this.array) throw new TypeError("this.array must be set first.");
+    for (const t of this.array) t.attachFiles(r);
+    return this;
+  }
+  async build() {
+    return this.pages = this.array.length, await this._verify(), this._loadList();
+  }
+  setArray(t) {
+    if (!(Array.isArray(t) && Boolean(t.length))) throw new TypeError("Cannot invoke Embeds class without a valid array to paginate.");
+    for (const [s, e] of t.entries()) {
+      if (!Boolean(e) || e.constructor !== Object || !Object.keys(e).length) {
+        if (e instanceof r.MessageEmbed) continue;
+        throw new TypeError(`(MessageEmbeds[${s}]) Cannot invoke Embeds class with an invalid MessageEmbed instance.`);
+      }
+      t[s] = new r.MessageEmbed(e);
     }
-    /**
-     * Adds a field to the fields of all embeds.
-     * @param name - The name of the field.
-     * @param value - The value of the field.
-     * @param inline - Whether the field is inline to the other fields.
-     */
-    addField(name, value, inline = false) {
-        if (!this.array)
-            throw new TypeError('this.array must be set first.');
-        for (const el of this.array)
-            el.addField(name, value, inline);
-        return this;
-    }
-    addFields(...fields) {
-        if (!this.array)
-            throw new TypeError('this.array must be set first.');
-        for (const el of this.array)
-            el.addFields(...fields);
-    }
-    /**
-     * Files to attach to all embeds.
-     * @param files - Files to attach.
-     */
-    attachFiles(files) {
-        if (!this.array)
-            throw new TypeError('this.array must be set first.');
-        for (const el of this.array)
-            el.attachFiles(files);
-        return this;
-    }
-    /**
-     * Build the Pagination Embeds.
-     *
-     * ### Example
-     * ```js
-     *   const { Embeds } = require('discord-paginationembed');
-     *   const { MessageEmbed } = require('discord.js');
-     *
-     *   // Under message event.
-     *   const embeds = [];
-     *
-     *   for (let i = 0; i < 5; ++i)
-     *    embeds.push(new MessageEmbed().addField('Page', i + 1));
-     *
-     *   new Embeds()
-     *    .setAuthorizedUsers([message.author.id])
-     *    .setChannel(message.channel)
-     *    .setClientAssets({ prompt: 'Yo {{user}} wat peige?!?!?' })
-     *    .setArray(embeds)
-     *    .setPageIndicator(false)
-     *    .setPage(1)
-     *    .setTimeout(69000)
-     *    .setNavigationEmojis({
-     *      back: '◀',
-     *      jump: '↗',
-     *      forward: '▶',
-     *      delete: '🗑'
-     *    })
-     *    .setFunctionEmojis({
-     *      '⬆': (_, instance) => {
-     *        for (const embed of instance.array)
-     *          embed.fields[0].value++;
-     *        },
-     *      '⬇': (_, instance) => {
-     *         for (const embed of instance.array)
-     *           embed.fields[0].value--;
-     *        }
-     *    })
-     *    .setDescription('This is one of my embeds with this message!')
-     *    .setColor(0xFF00AE)
-     *    .setTimestamp()
-     *    .build();```
-     */
-    async build() {
-        this.pages = this.array.length;
-        await this._verify();
-        return this._loadList();
-    }
-    /**
-     * Sets the array of MessageEmbed to paginate.
-     * @param array - An array of MessageEmbed to paginate.
-     */
-    setArray(array) {
-        const isValidArray = Array.isArray(array) && Boolean(array.length);
-        if (!isValidArray)
-            throw new TypeError('Cannot invoke Embeds class without a valid array to paginate.');
-        for (const [i, v] of array.entries())
-            if (Boolean(v) && v.constructor === Object && Object.keys(v).length)
-                array[i] = new discord_js_1.MessageEmbed(v);
-            else if (v instanceof discord_js_1.MessageEmbed)
-                continue;
-            else
-                throw new TypeError(`(MessageEmbeds[${i}]) Cannot invoke Embeds class with an invalid MessageEmbed instance.`);
-        this.array = array;
-        return this;
-    }
-    /**
-     * Set the author of all embeds.
-     * @param name - The name of the author.
-     * @param iconURL - The icon URL of the author.
-     * @param url - The URL of the author.
-     */
-    setAuthor(name, iconURL, url) {
-        if (!this.array)
-            throw new TypeError('this.array must be set first.');
-        for (const el of this.array)
-            el.setAuthor(name, iconURL, url);
-        return this;
-    }
-    /**
-     * Sets the color of all embeds.
-     * @param color - The color of all embeds.
-     */
-    setColor(color) {
-        if (!this.array)
-            throw new TypeError('this.array must be set first.');
-        for (const el of this.array)
-            el.setColor(color);
-        return this;
-    }
-    /**
-     * Sets the description of all embeds.
-     * @param description - The description of all embeds.
-     */
-    setDescription(description) {
-        if (!this.array)
-            throw new TypeError('this.array must be set first.');
-        for (const el of this.array)
-            el.setDescription(description);
-        return this;
-    }
-    /**
-     * Sets the footer of all embeds.
-     * @param text - The footer text.
-     * @param iconURL - URL for the footer's icon.
-     */
-    setFooter(text, iconURL) {
-        if (!this.array)
-            throw new TypeError('this.array must be set first.');
-        for (const el of this.array)
-            el.setFooter(text, iconURL);
-        return this;
-    }
-    /**
-     * Sets the image of all embeds.
-     * @param url - The image of all embeds.
-     */
-    setImage(url) {
-        if (!this.array)
-            throw new TypeError('this.array must be set first.');
-        for (const el of this.array)
-            el.setImage(url);
-        return this;
-    }
-    /**
-     * Sets the thumbnail of all embeds.
-     * @param url - The thumbnail of all embeds.
-     */
-    setThumbnail(url) {
-        if (!this.array)
-            throw new TypeError('this.array must be set first.');
-        for (const el of this.array)
-            el.setThumbnail(url);
-        return this;
-    }
-    /**
-     * Sets the timestamp of all embeds.
-     * @param timestamp - The timestamp or date.
-     */
-    setTimestamp(timestamp) {
-        if (!this.array)
-            throw new TypeError('this.array must be set first.');
-        for (const el of this.array)
-            el.setTimestamp(timestamp);
-        return this;
-    }
-    /**
-     * Sets the title of all embeds.
-     * @param title - The title of all embeds.
-     */
-    setTitle(title) {
-        if (!this.array)
-            throw new TypeError('this.array must be set first.');
-        for (const el of this.array)
-            el.setTitle(title);
-        return this;
-    }
-    /**
-     * Sets the URL of all embeds.
-     * @param url - The URL of all embeds.
-     */
-    setURL(url) {
-        if (!this.array)
-            throw new TypeError('this.array must be set first.');
-        for (const el of this.array)
-            el.setURL(url);
-        return this;
-    }
-    /**
-     * Removes, replaces, and inserts fields in all embeds (max 25).
-     * @param index - The index to start at.
-     * @param deleteCount - The number of fields to remove.
-     * @param name - The name of the field.
-     * @param value - The value of the field.
-     * @param inline - Set the field to display inline.
-     */
-    spliceFields(index, deleteCount, name, value, inline) {
-        if (!this.array)
-            throw new TypeError('this.array must be set first.');
-        for (const el of this.array)
-            el.spliceFields(index, deleteCount, name, value, inline);
-        return this;
-    }
-    /** Transforms all embeds to plain objects. */
-    toJSON() {
-        if (!this.array)
-            throw new TypeError('this.array must be set first.');
-        return this.array.map(m => m.toJSON());
-    }
-    /** @ignore */
-    async _loadList(callNavigation = true) {
-        if (this.listenerCount('pageUpdate'))
-            this.emit('pageUpdate');
-        const embed = new discord_js_1.MessageEmbed(this.currentEmbed);
-        const isFooter = this.usePageIndicator === 'footer';
-        const shouldIndicate = this.usePageIndicator && !isFooter
-            ? this.pages === 1
-                ? undefined
-                : this.pageIndicator
-            : undefined;
-        if (isFooter)
-            embed.setFooter(this.pageIndicator, embed.footer.iconURL);
-        if (this.clientAssets.message)
-            await this.clientAssets.message.edit(shouldIndicate, { embed });
-        else
-            this.clientAssets.message = await this.channel.send(shouldIndicate, { embed });
-        return super._loadList(callNavigation);
-    }
+    return this.array = t, this;
+  }
+  setAuthor(r, t, s) {
+    if (!this.array) throw new TypeError("this.array must be set first.");
+    for (const e of this.array) e.setAuthor(r, t, s);
+    return this;
+  }
+  setColor(r) {
+    if (!this.array) throw new TypeError("this.array must be set first.");
+    for (const t of this.array) t.setColor(r);
+    return this;
+  }
+  setDescription(r) {
+    if (!this.array) throw new TypeError("this.array must be set first.");
+    for (const t of this.array) t.setDescription(r);
+    return this;
+  }
+  setFooter(r, t) {
+    if (!this.array) throw new TypeError("this.array must be set first.");
+    for (const s of this.array) s.setFooter(r, t);
+    return this;
+  }
+  setImage(r) {
+    if (!this.array) throw new TypeError("this.array must be set first.");
+    for (const t of this.array) t.setImage(r);
+    return this;
+  }
+  setThumbnail(r) {
+    if (!this.array) throw new TypeError("this.array must be set first.");
+    for (const t of this.array) t.setThumbnail(r);
+    return this;
+  }
+  setTimestamp(r) {
+    if (!this.array) throw new TypeError("this.array must be set first.");
+    for (const t of this.array) t.setTimestamp(r);
+    return this;
+  }
+  setTitle(r) {
+    if (!this.array) throw new TypeError("this.array must be set first.");
+    for (const t of this.array) t.setTitle(r);
+    return this;
+  }
+  setURL(r) {
+    if (!this.array) throw new TypeError("this.array must be set first.");
+    for (const t of this.array) t.setURL(r);
+    return this;
+  }
+  spliceFields(r, t, s, e, i) {
+    if (!this.array) throw new TypeError("this.array must be set first.");
+    for (const a of this.array) a.spliceFields(r, t, s, e, i);
+    return this;
+  }
+  toJSON() {
+    if (!this.array) throw new TypeError("this.array must be set first.");
+    return this.array.map((r => r.toJSON()));
+  }
+  async _loadList(t = !0) {
+    this.listenerCount("pageUpdate") && this.emit("pageUpdate");
+    const s = new r.MessageEmbed(this.currentEmbed), e = "footer" === this.usePageIndicator, i = this.usePageIndicator && !e ? 1 === this.pages ? void 0 : this.pageIndicator : void 0;
+    return e && s.setFooter(this.pageIndicator, s.footer.iconURL), this.clientAssets.message ? await this.clientAssets.message.edit(i, {
+      embed: s
+    }) : this.clientAssets.message = await this.channel.send(i, {
+      embed: s
+    }), super._loadList(t);
+  }
 }
-exports.Embeds = Embeds;
+
+exports.Embeds = s;

--- a/bin/Embeds.js
+++ b/bin/Embeds.js
@@ -1,104 +1,255 @@
 "use strict";
-
-Object.defineProperty(exports, "__esModule", {
-  value: !0
-});
-
-const r = require("discord.js"), t = require("./base");
-
-exports.Embeds = class extends t.PaginationEmbed {
-  get currentEmbed() {
-    return this.array[this.page - 1];
-  }
-  addField(r, t, s = !1) {
-    if (!this.array) throw new TypeError("this.array must be set first.");
-    for (const e of this.array) e.addField(r, t, s);
-    return this;
-  }
-  addFields(...r) {
-    if (!this.array) throw new TypeError("this.array must be set first.");
-    for (const t of this.array) t.addFields(...r);
-  }
-  attachFiles(r) {
-    if (!this.array) throw new TypeError("this.array must be set first.");
-    for (const t of this.array) t.attachFiles(r);
-    return this;
-  }
-  async build() {
-    return this.pages = this.array.length, await this._verify(), this._loadList();
-  }
-  setArray(t) {
-    if (!Array.isArray(t) || !Boolean(t.length)) throw new TypeError("Cannot invoke Embeds class without a valid array to paginate.");
-    for (const [s, e] of t.entries()) {
-      if (!Boolean(e) || e.constructor !== Object || !Object.keys(e).length) {
-        if (e instanceof r.MessageEmbed) continue;
-        throw new TypeError(`(MessageEmbeds[${s}]) Cannot invoke Embeds class with an invalid MessageEmbed instance.`);
-      }
-      t[s] = new r.MessageEmbed(e);
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.Embeds = void 0;
+const discord_js_1 = require("discord.js");
+const base_1 = require("./base");
+/**
+ * A pagination mode that uses an array of MessageEmbed to paginate.
+ * @extends [[PaginationEmbed]]
+ * @noInheritDoc
+ */
+class Embeds extends base_1.PaginationEmbed {
+    /** Embed in the current page. */
+    get currentEmbed() {
+        return this.array[this.page - 1];
     }
-    return this.array = t, this;
-  }
-  setAuthor(r, t, s) {
-    if (!this.array) throw new TypeError("this.array must be set first.");
-    for (const e of this.array) e.setAuthor(r, t, s);
-    return this;
-  }
-  setColor(r) {
-    if (!this.array) throw new TypeError("this.array must be set first.");
-    for (const t of this.array) t.setColor(r);
-    return this;
-  }
-  setDescription(r) {
-    if (!this.array) throw new TypeError("this.array must be set first.");
-    for (const t of this.array) t.setDescription(r);
-    return this;
-  }
-  setFooter(r, t) {
-    if (!this.array) throw new TypeError("this.array must be set first.");
-    for (const s of this.array) s.setFooter(r, t);
-    return this;
-  }
-  setImage(r) {
-    if (!this.array) throw new TypeError("this.array must be set first.");
-    for (const t of this.array) t.setImage(r);
-    return this;
-  }
-  setThumbnail(r) {
-    if (!this.array) throw new TypeError("this.array must be set first.");
-    for (const t of this.array) t.setThumbnail(r);
-    return this;
-  }
-  setTimestamp(r) {
-    if (!this.array) throw new TypeError("this.array must be set first.");
-    for (const t of this.array) t.setTimestamp(r);
-    return this;
-  }
-  setTitle(r) {
-    if (!this.array) throw new TypeError("this.array must be set first.");
-    for (const t of this.array) t.setTitle(r);
-    return this;
-  }
-  setURL(r) {
-    if (!this.array) throw new TypeError("this.array must be set first.");
-    for (const t of this.array) t.setURL(r);
-    return this;
-  }
-  spliceFields(r, t, s, e, i) {
-    if (!this.array) throw new TypeError("this.array must be set first.");
-    for (const a of this.array) a.spliceFields(r, t, s, e, i);
-    return this;
-  }
-  toJSON() {
-    if (!this.array) throw new TypeError("this.array must be set first.");
-    return this.array.map(r => r.toJSON());
-  }
-  async _loadList(t = !0) {
-    this.listenerCount("pageUpdate") && this.emit("pageUpdate");
-    const s = new r.MessageEmbed(this.currentEmbed), e = "footer" === this.usePageIndicator, i = this.usePageIndicator && !e ? 1 === this.pages ? void 0 : this.pageIndicator : void 0;
-    return e && s.setFooter(this.pageIndicator, s.footer.iconURL), this.clientAssets.message ? await this.clientAssets.message.edit(i, {
-      embed: s
-    }) : this.clientAssets.message = await this.channel.send(i, {
-      embed: s
-    }), super._loadList(t);
-  }
-};
+    /**
+     * Adds a field to the fields of all embeds.
+     * @param name - The name of the field.
+     * @param value - The value of the field.
+     * @param inline - Whether the field is inline to the other fields.
+     */
+    addField(name, value, inline = false) {
+        if (!this.array)
+            throw new TypeError('this.array must be set first.');
+        for (const el of this.array)
+            el.addField(name, value, inline);
+        return this;
+    }
+    addFields(...fields) {
+        if (!this.array)
+            throw new TypeError('this.array must be set first.');
+        for (const el of this.array)
+            el.addFields(...fields);
+    }
+    /**
+     * Files to attach to all embeds.
+     * @param files - Files to attach.
+     */
+    attachFiles(files) {
+        if (!this.array)
+            throw new TypeError('this.array must be set first.');
+        for (const el of this.array)
+            el.attachFiles(files);
+        return this;
+    }
+    /**
+     * Build the Pagination Embeds.
+     *
+     * ### Example
+     * ```js
+     *   const { Embeds } = require('discord-paginationembed');
+     *   const { MessageEmbed } = require('discord.js');
+     *
+     *   // Under message event.
+     *   const embeds = [];
+     *
+     *   for (let i = 0; i < 5; ++i)
+     *    embeds.push(new MessageEmbed().addField('Page', i + 1));
+     *
+     *   new Embeds()
+     *    .setAuthorizedUsers([message.author.id])
+     *    .setChannel(message.channel)
+     *    .setClientAssets({ prompt: 'Yo {{user}} wat peige?!?!?' })
+     *    .setArray(embeds)
+     *    .setPageIndicator(false)
+     *    .setPage(1)
+     *    .setTimeout(69000)
+     *    .setNavigationEmojis({
+     *      back: '◀',
+     *      jump: '↗',
+     *      forward: '▶',
+     *      delete: '🗑'
+     *    })
+     *    .setFunctionEmojis({
+     *      '⬆': (_, instance) => {
+     *        for (const embed of instance.array)
+     *          embed.fields[0].value++;
+     *        },
+     *      '⬇': (_, instance) => {
+     *         for (const embed of instance.array)
+     *           embed.fields[0].value--;
+     *        }
+     *    })
+     *    .setDescription('This is one of my embeds with this message!')
+     *    .setColor(0xFF00AE)
+     *    .setTimestamp()
+     *    .build();```
+     */
+    async build() {
+        this.pages = this.array.length;
+        await this._verify();
+        return this._loadList();
+    }
+    /**
+     * Sets the array of MessageEmbed to paginate.
+     * @param array - An array of MessageEmbed to paginate.
+     */
+    setArray(array) {
+        const isValidArray = Array.isArray(array) && Boolean(array.length);
+        if (!isValidArray)
+            throw new TypeError('Cannot invoke Embeds class without a valid array to paginate.');
+        for (const [i, v] of array.entries())
+            if (Boolean(v) && v.constructor === Object && Object.keys(v).length)
+                array[i] = new discord_js_1.MessageEmbed(v);
+            else if (v instanceof discord_js_1.MessageEmbed)
+                continue;
+            else
+                throw new TypeError(`(MessageEmbeds[${i}]) Cannot invoke Embeds class with an invalid MessageEmbed instance.`);
+        this.array = array;
+        return this;
+    }
+    /**
+     * Set the author of all embeds.
+     * @param name - The name of the author.
+     * @param iconURL - The icon URL of the author.
+     * @param url - The URL of the author.
+     */
+    setAuthor(name, iconURL, url) {
+        if (!this.array)
+            throw new TypeError('this.array must be set first.');
+        for (const el of this.array)
+            el.setAuthor(name, iconURL, url);
+        return this;
+    }
+    /**
+     * Sets the color of all embeds.
+     * @param color - The color of all embeds.
+     */
+    setColor(color) {
+        if (!this.array)
+            throw new TypeError('this.array must be set first.');
+        for (const el of this.array)
+            el.setColor(color);
+        return this;
+    }
+    /**
+     * Sets the description of all embeds.
+     * @param description - The description of all embeds.
+     */
+    setDescription(description) {
+        if (!this.array)
+            throw new TypeError('this.array must be set first.');
+        for (const el of this.array)
+            el.setDescription(description);
+        return this;
+    }
+    /**
+     * Sets the footer of all embeds.
+     * @param text - The footer text.
+     * @param iconURL - URL for the footer's icon.
+     */
+    setFooter(text, iconURL) {
+        if (!this.array)
+            throw new TypeError('this.array must be set first.');
+        for (const el of this.array)
+            el.setFooter(text, iconURL);
+        return this;
+    }
+    /**
+     * Sets the image of all embeds.
+     * @param url - The image of all embeds.
+     */
+    setImage(url) {
+        if (!this.array)
+            throw new TypeError('this.array must be set first.');
+        for (const el of this.array)
+            el.setImage(url);
+        return this;
+    }
+    /**
+     * Sets the thumbnail of all embeds.
+     * @param url - The thumbnail of all embeds.
+     */
+    setThumbnail(url) {
+        if (!this.array)
+            throw new TypeError('this.array must be set first.');
+        for (const el of this.array)
+            el.setThumbnail(url);
+        return this;
+    }
+    /**
+     * Sets the timestamp of all embeds.
+     * @param timestamp - The timestamp or date.
+     */
+    setTimestamp(timestamp) {
+        if (!this.array)
+            throw new TypeError('this.array must be set first.');
+        for (const el of this.array)
+            el.setTimestamp(timestamp);
+        return this;
+    }
+    /**
+     * Sets the title of all embeds.
+     * @param title - The title of all embeds.
+     */
+    setTitle(title) {
+        if (!this.array)
+            throw new TypeError('this.array must be set first.');
+        for (const el of this.array)
+            el.setTitle(title);
+        return this;
+    }
+    /**
+     * Sets the URL of all embeds.
+     * @param url - The URL of all embeds.
+     */
+    setURL(url) {
+        if (!this.array)
+            throw new TypeError('this.array must be set first.');
+        for (const el of this.array)
+            el.setURL(url);
+        return this;
+    }
+    /**
+     * Removes, replaces, and inserts fields in all embeds (max 25).
+     * @param index - The index to start at.
+     * @param deleteCount - The number of fields to remove.
+     * @param name - The name of the field.
+     * @param value - The value of the field.
+     * @param inline - Set the field to display inline.
+     */
+    spliceFields(index, deleteCount, name, value, inline) {
+        if (!this.array)
+            throw new TypeError('this.array must be set first.');
+        for (const el of this.array)
+            el.spliceFields(index, deleteCount, name, value, inline);
+        return this;
+    }
+    /** Transforms all embeds to plain objects. */
+    toJSON() {
+        if (!this.array)
+            throw new TypeError('this.array must be set first.');
+        return this.array.map(m => m.toJSON());
+    }
+    /** @ignore */
+    async _loadList(callNavigation = true) {
+        if (this.listenerCount('pageUpdate'))
+            this.emit('pageUpdate');
+        const embed = new discord_js_1.MessageEmbed(this.currentEmbed);
+        const isFooter = this.usePageIndicator === 'footer';
+        const shouldIndicate = this.usePageIndicator && !isFooter
+            ? this.pages === 1
+                ? undefined
+                : this.pageIndicator
+            : undefined;
+        if (isFooter)
+            embed.setFooter(this.pageIndicator, embed.footer.iconURL);
+        if (this.clientAssets.message)
+            await this.clientAssets.message.edit(shouldIndicate, { embed });
+        else
+            this.clientAssets.message = await this.channel.send(shouldIndicate, { embed });
+        return super._loadList(callNavigation);
+    }
+}
+exports.Embeds = Embeds;

--- a/bin/FieldsEmbed.js
+++ b/bin/FieldsEmbed.js
@@ -1,52 +1,127 @@
 "use strict";
-
-Object.defineProperty(exports, "__esModule", {
-  value: !0
-});
-
-const e = require("discord.js"), t = require("./base");
-
-exports.FieldsEmbed = class extends t.PaginationEmbed {
-  constructor() {
-    super(), this.elementsPerPage = 10, this.embed = new e.MessageEmbed();
-  }
-  get elementList() {
-    const e = (this.page - 1) * this.elementsPerPage, t = e + this.elementsPerPage;
-    return this.array.slice(e, t);
-  }
-  async build() {
-    this.pages = Math.ceil(this.array.length / this.elementsPerPage), await this._verify();
-    const e = this.embed.fields;
-    this.embed.fields = [];
-    for (const t of e) "function" == typeof t.value ? this.formatField(t.name, t.value, t.inline) : this.embed.addField(t.name, t.value, t.inline);
-    if (!this.embed.fields.filter(e => "function" == typeof e.value).length) throw new Error("Cannot invoke FieldsEmbed class without at least one formatted field to paginate.");
-    return this._loadList();
-  }
-  formatField(e, t, s = !0) {
-    if ("function" != typeof t) throw new TypeError("formatField() value parameter only takes a function.");
-    return this.embed.fields.push({
-      name: e,
-      value: t,
-      inline: s
-    }), this;
-  }
-  setElementsPerPage(e) {
-    if ("number" != typeof e) throw new TypeError("setElementsPerPage() only accepts number type.");
-    return this.elementsPerPage = e, this;
-  }
-  async _drawList() {
-    const t = new e.MessageEmbed(this.embed);
-    t.fields = [];
-    for (const e of this.embed.fields) t.addField(e.name, "function" == typeof e.value ? this.elementList.map(e.value).join("\n") : e.value, e.inline);
-    return t;
-  }
-  async _loadList(e = !0) {
-    this.listenerCount("pageUpdate") && this.emit("pageUpdate");
-    const t = await this._drawList(), s = "footer" === this.usePageIndicator, i = this.usePageIndicator && !s ? 1 === this.pages ? void 0 : this.pageIndicator : void 0;
-    return s && t.setFooter(this.pageIndicator, t.footer.iconURL), this.clientAssets.message ? await this.clientAssets.message.edit(i, {
-      embed: t
-    }) : this.clientAssets.message = await this.channel.send(i, {
-      embed: t
-    }), super._loadList(e);
-  }
-};
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.FieldsEmbed = void 0;
+const discord_js_1 = require("discord.js");
+const base_1 = require("./base");
+/**
+ * A pagination mode that uses a MessageEmbed with a field(s) containing the elements to paginate.
+ * @extends [[PaginationEmbed]]
+ * @noInheritDoc
+ */
+class FieldsEmbed extends base_1.PaginationEmbed {
+    constructor() {
+        super();
+        this.elementsPerPage = 10;
+        this.embed = new discord_js_1.MessageEmbed();
+    }
+    /** Elements in the current page. */
+    get elementList() {
+        const begin = (this.page - 1) * this.elementsPerPage;
+        const end = begin + this.elementsPerPage;
+        return this.array.slice(begin, end);
+    }
+    /**
+     * Build the Pagination Fields Embed.
+     *
+     * ### Example
+     * ```js
+     *   const { FieldsEmbed } = require('discord-paginationembed');
+     *
+     *   // Under message event.
+     *   new FieldsEmbed()
+     *    .setAuthorizedUsers([message.author.id])
+     *    .setChannel(message.channel)
+     *    .setClientAssets({ prompt: 'Yo {{user}} wat peige?!?!?' })
+     *    .setArray([{ name: 'John Doe' }, { name: 'Jane Doe' }])
+     *    .setElementsPerPage(1)
+     *    .setPageIndicator(false)
+     *    .formatField('Name', el => el.name)
+     *    .setPage(1)
+     *    .setTimeout(69000)
+     *    .setNavigationEmojis({
+     *      back: '◀',
+     *      jump: '↗',
+     *      forward: '▶',
+     *      delete: '🗑'
+     *    })
+     *    .setFunctionEmojis({
+     *      '🔄': (user, instance) => {
+     *        const field = instance.embed.fields[0];
+     *
+     *        if (field.name === 'Name')
+     *          field.name = user.tag;
+     *        else
+     *          field.name = 'Name';
+     *      }
+     *    })
+     *    .build();```
+     */
+    async build() {
+        this.pages = Math.ceil(this.array.length / this.elementsPerPage);
+        await this._verify();
+        const fields = this.embed.fields;
+        this.embed.fields = [];
+        for (const field of fields)
+            if (typeof field.value === 'function')
+                this.formatField(field.name, field.value, field.inline);
+            else
+                this.embed.addField(field.name, field.value, field.inline);
+        const hasPaginateField = this.embed.fields.filter(f => typeof f.value === 'function').length;
+        if (!hasPaginateField)
+            throw new Error('Cannot invoke FieldsEmbed class without at least one formatted field to paginate.');
+        return this._loadList();
+    }
+    /**
+     * Adds a field to the embed.
+     * Same as MessageEmbed.addField, but value takes a function instead.
+     * @param name - Name of the field.
+     * @param value - Value of the field. Function for `Array.prototype.map().join('\n')`.
+     * @param inline - Whether the field is inline with other field. Default: `true`
+     */
+    formatField(name, value, inline = true) {
+        if (typeof value !== 'function')
+            throw new TypeError('formatField() value parameter only takes a function.');
+        // @ts-ignore
+        this.embed.fields.push({ name, value, inline });
+        return this;
+    }
+    /**
+     * Sets the maximum number of elements to be displayed per page.
+     * @param max - Maximum number of elements to be displayed per page.
+     */
+    setElementsPerPage(max) {
+        if (typeof max !== 'number')
+            throw new TypeError('setElementsPerPage() only accepts number type.');
+        this.elementsPerPage = max;
+        return this;
+    }
+    async _drawList() {
+        const embed = new discord_js_1.MessageEmbed(this.embed);
+        embed.fields = [];
+        for (const field of this.embed.fields)
+            embed.addField(field.name, typeof field.value === 'function'
+                ? this.elementList.map(field.value).join('\n')
+                : field.value, field.inline);
+        return embed;
+    }
+    /** @ignore */
+    async _loadList(callNavigation = true) {
+        if (this.listenerCount('pageUpdate'))
+            this.emit('pageUpdate');
+        const embed = await this._drawList();
+        const isFooter = this.usePageIndicator === 'footer';
+        const shouldIndicate = this.usePageIndicator && !isFooter
+            ? this.pages === 1
+                ? undefined
+                : this.pageIndicator
+            : undefined;
+        if (isFooter)
+            embed.setFooter(this.pageIndicator, embed.footer.iconURL);
+        if (this.clientAssets.message)
+            await this.clientAssets.message.edit(shouldIndicate, { embed });
+        else
+            this.clientAssets.message = await this.channel.send(shouldIndicate, { embed });
+        return super._loadList(callNavigation);
+    }
+}
+exports.FieldsEmbed = FieldsEmbed;

--- a/bin/FieldsEmbed.js
+++ b/bin/FieldsEmbed.js
@@ -1,127 +1,54 @@
 "use strict";
-Object.defineProperty(exports, "__esModule", { value: true });
-exports.FieldsEmbed = void 0;
-const discord_js_1 = require("discord.js");
-const base_1 = require("./base");
-/**
- * A pagination mode that uses a MessageEmbed with a field(s) containing the elements to paginate.
- * @extends [[PaginationEmbed]]
- * @noInheritDoc
- */
-class FieldsEmbed extends base_1.PaginationEmbed {
-    constructor() {
-        super();
-        this.elementsPerPage = 10;
-        this.embed = new discord_js_1.MessageEmbed();
-    }
-    /** Elements in the current page. */
-    get elementList() {
-        const begin = (this.page - 1) * this.elementsPerPage;
-        const end = begin + this.elementsPerPage;
-        return this.array.slice(begin, end);
-    }
-    /**
-     * Build the Pagination Fields Embed.
-     *
-     * ### Example
-     * ```js
-     *   const { FieldsEmbed } = require('discord-paginationembed');
-     *
-     *   // Under message event.
-     *   new FieldsEmbed()
-     *    .setAuthorizedUsers([message.author.id])
-     *    .setChannel(message.channel)
-     *    .setClientAssets({ prompt: 'Yo {{user}} wat peige?!?!?' })
-     *    .setArray([{ name: 'John Doe' }, { name: 'Jane Doe' }])
-     *    .setElementsPerPage(1)
-     *    .setPageIndicator(false)
-     *    .formatField('Name', el => el.name)
-     *    .setPage(1)
-     *    .setTimeout(69000)
-     *    .setNavigationEmojis({
-     *      back: '◀',
-     *      jump: '↗',
-     *      forward: '▶',
-     *      delete: '🗑'
-     *    })
-     *    .setFunctionEmojis({
-     *      '🔄': (user, instance) => {
-     *        const field = instance.embed.fields[0];
-     *
-     *        if (field.name === 'Name')
-     *          field.name = user.tag;
-     *        else
-     *          field.name = 'Name';
-     *      }
-     *    })
-     *    .build();```
-     */
-    async build() {
-        this.pages = Math.ceil(this.array.length / this.elementsPerPage);
-        await this._verify();
-        const fields = this.embed.fields;
-        this.embed.fields = [];
-        for (const field of fields)
-            if (typeof field.value === 'function')
-                this.formatField(field.name, field.value, field.inline);
-            else
-                this.embed.addField(field.name, field.value, field.inline);
-        const hasPaginateField = this.embed.fields.filter(f => typeof f.value === 'function').length;
-        if (!hasPaginateField)
-            throw new Error('Cannot invoke FieldsEmbed class without at least one formatted field to paginate.');
-        return this._loadList();
-    }
-    /**
-     * Adds a field to the embed.
-     * Same as MessageEmbed.addField, but value takes a function instead.
-     * @param name - Name of the field.
-     * @param value - Value of the field. Function for `Array.prototype.map().join('\n')`.
-     * @param inline - Whether the field is inline with other field. Default: `true`
-     */
-    formatField(name, value, inline = true) {
-        if (typeof value !== 'function')
-            throw new TypeError('formatField() value parameter only takes a function.');
-        // @ts-ignore
-        this.embed.fields.push({ name, value, inline });
-        return this;
-    }
-    /**
-     * Sets the maximum number of elements to be displayed per page.
-     * @param max - Maximum number of elements to be displayed per page.
-     */
-    setElementsPerPage(max) {
-        if (typeof max !== 'number')
-            throw new TypeError('setElementsPerPage() only accepts number type.');
-        this.elementsPerPage = max;
-        return this;
-    }
-    async _drawList() {
-        const embed = new discord_js_1.MessageEmbed(this.embed);
-        embed.fields = [];
-        for (const field of this.embed.fields)
-            embed.addField(field.name, typeof field.value === 'function'
-                ? this.elementList.map(field.value).join('\n')
-                : field.value, field.inline);
-        return embed;
-    }
-    /** @ignore */
-    async _loadList(callNavigation = true) {
-        if (this.listenerCount('pageUpdate'))
-            this.emit('pageUpdate');
-        const embed = await this._drawList();
-        const isFooter = this.usePageIndicator === 'footer';
-        const shouldIndicate = this.usePageIndicator && !isFooter
-            ? this.pages === 1
-                ? undefined
-                : this.pageIndicator
-            : undefined;
-        if (isFooter)
-            embed.setFooter(this.pageIndicator, embed.footer.iconURL);
-        if (this.clientAssets.message)
-            await this.clientAssets.message.edit(shouldIndicate, { embed });
-        else
-            this.clientAssets.message = await this.channel.send(shouldIndicate, { embed });
-        return super._loadList(callNavigation);
-    }
+
+Object.defineProperty(exports, "__esModule", {
+  value: !0
+}), exports.FieldsEmbed = void 0;
+
+const e = require("discord.js"), t = require("./base");
+
+class s extends t.PaginationEmbed {
+  constructor() {
+    super(), this.elementsPerPage = 10, this.embed = new e.MessageEmbed;
+  }
+  get elementList() {
+    const e = (this.page - 1) * this.elementsPerPage, t = e + this.elementsPerPage;
+    return this.array.slice(e, t);
+  }
+  async build() {
+    this.pages = Math.ceil(this.array.length / this.elementsPerPage), await this._verify();
+    const e = this.embed.fields;
+    this.embed.fields = [];
+    for (const t of e) "function" == typeof t.value ? this.formatField(t.name, t.value, t.inline) : this.embed.addField(t.name, t.value, t.inline);
+    if (!this.embed.fields.filter((e => "function" == typeof e.value)).length) throw new Error("Cannot invoke FieldsEmbed class without at least one formatted field to paginate.");
+    return this._loadList();
+  }
+  formatField(e, t, s = !0) {
+    if ("function" != typeof t) throw new TypeError("formatField() value parameter only takes a function.");
+    return this.embed.fields.push({
+      name: e,
+      value: t,
+      inline: s
+    }), this;
+  }
+  setElementsPerPage(e) {
+    if ("number" != typeof e) throw new TypeError("setElementsPerPage() only accepts number type.");
+    return this.elementsPerPage = e, this;
+  }
+  async _drawList() {
+    const t = new e.MessageEmbed(this.embed);
+    t.fields = [];
+    for (const e of this.embed.fields) t.addField(e.name, "function" == typeof e.value ? this.elementList.map(e.value).join("\n") : e.value, e.inline);
+    return t;
+  }
+  async _loadList(e = !0) {
+    this.listenerCount("pageUpdate") && this.emit("pageUpdate");
+    const t = await this._drawList(), s = "footer" === this.usePageIndicator, i = this.usePageIndicator && !s ? 1 === this.pages ? void 0 : this.pageIndicator : void 0;
+    return s && t.setFooter(this.pageIndicator, t.footer.iconURL), this.clientAssets.message ? await this.clientAssets.message.edit(i, {
+      embed: t
+    }) : this.clientAssets.message = await this.channel.send(i, {
+      embed: t
+    }), super._loadList(e);
+  }
 }
-exports.FieldsEmbed = FieldsEmbed;
+
+exports.FieldsEmbed = s;

--- a/bin/base/index.js
+++ b/bin/base/index.js
@@ -1,495 +1,229 @@
 "use strict";
-Object.defineProperty(exports, "__esModule", { value: true });
-exports.PaginationEmbed = void 0;
-const events_1 = require("events");
-/** @ignore */
-const MESSAGE_DELETED = 'Client\'s message was deleted before being processed.';
-/**
- * The base class for Pagination Modes. **Do not invoke**.
- * @extends [EventEmitter](https://nodejs.org/api/events.html#events_class_eventemitter)
- * @noInheritDoc
- */
-class PaginationEmbed extends events_1.EventEmitter {
-    constructor() {
-        super();
-        this.authorizedUsers = [];
-        this.channel = null;
-        this.clientAssets = {};
-        this.usePageIndicator = false;
-        this.deleteOnTimeout = false;
-        this.page = 1;
-        this.timeout = 30000;
-        this.navigationEmojis = {
-            back: '◀',
-            jump: '↗',
-            forward: '▶',
-            delete: '🗑'
-        };
-        this.functionEmojis = {};
-        this.disabledNavigationEmojis = [];
-        this.emojisFunctionAfterNavigation = false;
-        this.pages = null;
-        this._disabledNavigationEmojiValues = [];
-        this._defaultNavigationEmojis = {
-            back: '◀',
-            jump: '↗',
-            forward: '▶',
-            delete: '🗑'
-        };
-        const makeCircles = (page, pages) => `${'○ '.repeat(page - 1)}● ${'○ '.repeat(pages - page)}`.trim();
-        this._defaultPageIndicators = {
-            text: (page, pages) => `Page ${page} of ${pages}`,
-            textcompact: (page, pages) => `${page}/${pages}`,
-            circle: (page, pages) => makeCircles(page, pages),
-            hybrid: (page, pages) => `[${page}/${pages}] ${makeCircles(page, pages)}`
-        };
-        this._pageIndicator = this._defaultPageIndicators.text;
+
+Object.defineProperty(exports, "__esModule", {
+  value: !0
+}), exports.PaginationEmbed = void 0;
+
+const t = require("events");
+
+class e extends t.EventEmitter {
+  constructor() {
+    super(), this.authorizedUsers = [], this.channel = null, this.clientAssets = {}, 
+    this.usePageIndicator = !1, this.deleteOnTimeout = !1, this.page = 1, this.timeout = 3e4, 
+    this.navigationEmojis = {
+      back: "◀",
+      jump: "↗",
+      forward: "▶",
+      delete: "🗑"
+    }, this.functionEmojis = {}, this.disabledNavigationEmojis = [], this.emojisFunctionAfterNavigation = !1, 
+    this.pages = null, this._disabledNavigationEmojiValues = [], this._defaultNavigationEmojis = {
+      back: "◀",
+      jump: "↗",
+      forward: "▶",
+      delete: "🗑"
+    };
+    const t = (t, e) => `${"○ ".repeat(t - 1)}● ${"○ ".repeat(e - t)}`.trim();
+    this._defaultPageIndicators = {
+      text: (t, e) => `Page ${t} of ${e}`,
+      textcompact: (t, e) => `${t}/${e}`,
+      circle: (e, i) => t(e, i),
+      hybrid: (e, i) => `[${e}/${i}] ${t(e, i)}`
+    }, this._pageIndicator = this._defaultPageIndicators.text;
+  }
+  get pageIndicator() {
+    return this._pageIndicator(this.page, this.pages);
+  }
+  build() {
+    throw new Error("Cannot invoke this class. Invoke with [PaginationEmbed.Embeds] or [PaginationEmbed.FieldsEmbed] instead.");
+  }
+  addFunctionEmoji(t, e) {
+    if (!(e instanceof Function)) throw new TypeError(`Callback for ${t} must be a function type.`);
+    return Object.assign(this.functionEmojis, {
+      [t]: e
+    }), this;
+  }
+  deleteFunctionEmoji(t) {
+    if (!(t in this.functionEmojis)) throw new Error(`${t} function emoji does not exist.`);
+    return delete this.functionEmojis[t], this;
+  }
+  resetEmojis() {
+    for (const t of Object.keys(this.functionEmojis)) delete this.functionEmojis[t];
+    return this.navigationEmojis = this._defaultNavigationEmojis, this;
+  }
+  setArray(t) {
+    if (!(Array.isArray(t) && Boolean(t.length))) throw new TypeError("Cannot invoke PaginationEmbed class without a valid array to paginate.");
+    return this.array = t, this;
+  }
+  setAuthorizedUsers(t) {
+    if (!Array.isArray(t) && "string" != typeof t) throw new TypeError("Cannot invoke PaginationEmbed class without a valid array.");
+    return this.authorizedUsers = Array.isArray(t) ? t : [ t ], this;
+  }
+  setChannel(t) {
+    return this.channel = t, this;
+  }
+  setClientAssets(t) {
+    if (!t) throw new TypeError("Cannot accept assets options as a non-object type.");
+    const {message: e} = t;
+    let {prompt: i} = t;
+    return i || (i = "{{user}}, To what page would you like to jump? Say `cancel` or `0` to cancel the prompt."), 
+    Object.assign(this.clientAssets, {
+      message: e,
+      prompt: i
+    }), this;
+  }
+  setDisabledNavigationEmojis(t) {
+    if (!Array.isArray(t)) throw new TypeError("Cannot invoke PaginationEmbed class without a valid array.");
+    const e = [], i = [];
+    for (const s of t) {
+      [ "back", "jump", "forward", "delete", "all" ].includes(s) ? i.push(s) : e.push(s);
     }
-    /** The formatted page indicator. Default format: `text` */
-    get pageIndicator() {
-        return this._pageIndicator(this.page, this.pages);
+    if (e.length) throw new TypeError(`Cannot invoke PaginationEmbed class with invalid navigation emoji(s): ${e.join(", ")}.`);
+    return this.disabledNavigationEmojis = i, this;
+  }
+  setEmojisFunctionAfterNavigation(t) {
+    if ("boolean" != typeof t) throw new TypeError("setEmojisFunctionAfterNavigation() only accepts boolean type.");
+    return this.emojisFunctionAfterNavigation = t, this;
+  }
+  setFunctionEmojis(t) {
+    for (const e of Object.keys(t)) {
+      const i = t[e];
+      this.addFunctionEmoji(e, i);
     }
-    build() {
-        throw new Error('Cannot invoke this class. Invoke with [PaginationEmbed.Embeds] or [PaginationEmbed.FieldsEmbed] instead.');
+    return this;
+  }
+  setNavigationEmojis(t) {
+    return Object.assign(this.navigationEmojis, t), this;
+  }
+  setPage(t) {
+    const e = "string" == typeof t;
+    if (isNaN(t) && !e) throw new TypeError("setPage() only accepts number/string type.");
+    const i = "back" === t ? 1 === this.page ? this.page : this.page - 1 : this.page === this.pages ? this.pages : this.page + 1;
+    return this.page = e ? i : t, this;
+  }
+  setTimeout(t) {
+    if ("number" != typeof t) throw new TypeError("setTimeout() only accepts number type.");
+    return this.timeout = t, this;
+  }
+  setPageIndicator(t, e) {
+    if ("boolean" != typeof t && ("string" != typeof t || "footer" !== t)) throw new TypeError("setPageIndicator()'s `enabled` parameter only accepts boolean/string type.");
+    if (this.usePageIndicator = t, e) {
+      const t = [ "text", "textcompact", "circle", "hybrid" ];
+      if ("string" == typeof e && t.includes(e)) this._pageIndicator = this._defaultPageIndicators[e]; else {
+        if ("function" != typeof e) throw new TypeError("setPageIndicator()'s `fn` parameter only accepts function/string type.");
+        this._pageIndicator = e;
+      }
     }
-    /**
-     * Adds a function emoji to the embed.
-     *
-     * ### Example
-     * ```js
-     *  <PaginationEmbed>.addFunctionEmoji('🅱', (_, instance) => {
-     *    const field = instance.embed.fields[0];
-     *
-     *    if (field.name.includes('🅱'))
-     *      field.name = 'Name';
-     *    else
-     *      field.name = 'Na🅱e';
-     *  });
-     * ```
-     * @param emoji - The emoji to use as the function's emoji.
-     * @param callback - The function to call upon pressing the function emoji.
-     */
-    addFunctionEmoji(emoji, callback) {
-        if (!(callback instanceof Function))
-            throw new TypeError(`Callback for ${emoji} must be a function type.`);
-        Object.assign(this.functionEmojis, { [emoji]: callback });
-        return this;
+    return this;
+  }
+  setDeleteOnTimeout(t) {
+    if ("boolean" != typeof t) throw new TypeError("deleteOnTimeout() only accepts boolean type.");
+    return this.deleteOnTimeout = t, this;
+  }
+  async _verify() {
+    if (this.setClientAssets(this.clientAssets), !this.channel) throw new Error("Cannot invoke PaginationEmbed class without a channel object set.");
+    if (!(this.page >= 1 && this.page <= this.pages)) throw new RangeError(`Page number is out of bounds. Max pages: ${this.pages}`);
+    return this._checkPermissions();
+  }
+  async _checkPermissions() {
+    const t = this.channel;
+    if (t.guild) {
+      const e = t.permissionsFor(t.client.user).missing([ "ADD_REACTIONS", "EMBED_LINKS", "VIEW_CHANNEL", "SEND_MESSAGES" ]);
+      if (e.length) throw new Error(`Cannot invoke PaginationEmbed class without required permissions: ${e.join(", ")}`);
     }
-    /**
-     * Deletes a function emoji.
-     * @param emoji - The emoji key to delete.
-     */
-    deleteFunctionEmoji(emoji) {
-        if (!(emoji in this.functionEmojis))
-            throw new Error(`${emoji} function emoji does not exist.`);
-        delete this.functionEmojis[emoji];
-        return this;
-    }
-    /** Deletes all function emojis, and then re-enables all navigation emojis. */
-    resetEmojis() {
-        for (const emoji of Object.keys(this.functionEmojis))
-            delete this.functionEmojis[emoji];
-        this.navigationEmojis = this._defaultNavigationEmojis;
-        return this;
-    }
-    /**
-     * Sets the array of elements to paginate. This must be called first before any other methods.
-     * @param array - An array of elements to paginate.
-     */
-    setArray(array) {
-        const isValidArray = Array.isArray(array) && Boolean(array.length);
-        if (!isValidArray)
-            throw new TypeError('Cannot invoke PaginationEmbed class without a valid array to paginate.');
-        this.array = array;
-        return this;
-    }
-    /**
-     * Set the authorized users to navigate the pages.
-     * @param users - A user ID or an array of user IDs.
-     */
-    setAuthorizedUsers(users) {
-        if (!(Array.isArray(users) || typeof users === 'string'))
-            throw new TypeError('Cannot invoke PaginationEmbed class without a valid array.');
-        this.authorizedUsers = Array.isArray(users) ? users : [users];
-        return this;
-    }
-    /**
-     * The channel where to send the embed.
-     * @param channel - The channel object.
-     */
-    setChannel(channel) {
-        this.channel = channel;
-        return this;
-    }
-    /**
-     * Sets the settings for assets for the client.
-     * @param assets - The assets for the client.
-     */
-    setClientAssets(assets) {
-        if (!assets)
-            throw new TypeError('Cannot accept assets options as a non-object type.');
-        const { message } = assets;
-        let { prompt } = assets;
-        if (!prompt)
-            prompt = '{{user}}, To what page would you like to jump? Say `cancel` or `0` to cancel the prompt.';
-        Object.assign(this.clientAssets, { message, prompt });
-        return this;
-    }
-    /**
-     * Sets the disabled navigation emojis.
-     *
-     * ### Example
-     * ```js
-     *  // Disable specific navigation emojis
-     *  <PaginationEmbed>.setDisabledNavigationEmojis(['delete', 'jump']);
-     *
-     *  // Disable all navigation emojis
-     *  <PaginationEmbed>.setDisabledNavigationEmojis(['all']);
-     * ```
-     *
-     * @param emojis  - An array of navigation emojis to disable.
-     */
-    setDisabledNavigationEmojis(emojis) {
-        if (!Array.isArray(emojis))
-            throw new TypeError('Cannot invoke PaginationEmbed class without a valid array.');
-        const invalid = [];
-        const verified = [];
-        for (const emoji of emojis) {
-            const validEmojis = ['back', 'jump', 'forward', 'delete', 'all'];
-            if (validEmojis.includes(emoji))
-                verified.push(emoji);
-            else
-                invalid.push(emoji);
+    return !0;
+  }
+  _enabled(t) {
+    return !this.disabledNavigationEmojis.includes("all") && !this.disabledNavigationEmojis.includes(t);
+  }
+  async _drawEmojis() {
+    return this.emojisFunctionAfterNavigation ? (await this._drawNavigationEmojis(), 
+    await this._drawFunctionEmojis()) : (await this._drawFunctionEmojis(), await this._drawNavigationEmojis()), 
+    this.listenerCount("start") && this.emit("start"), this._awaitResponse();
+  }
+  async _drawFunctionEmojis() {
+    if (Object.keys(this.functionEmojis).length) for (const t of Object.keys(this.functionEmojis)) await this.clientAssets.message.react(t);
+  }
+  async _drawNavigationEmojis() {
+    this._enabled("back") && this.pages > 1 && await this.clientAssets.message.react(this.navigationEmojis.back), 
+    this._enabled("jump") && this.pages > 2 && await this.clientAssets.message.react(this.navigationEmojis.jump), 
+    this._enabled("forward") && this.pages > 1 && await this.clientAssets.message.react(this.navigationEmojis.forward), 
+    this._enabled("delete") && await this.clientAssets.message.react(this.navigationEmojis.delete);
+  }
+  _loadList(t = !0) {
+    if (t) return this._drawEmojis();
+  }
+  async _loadPage(t = 1) {
+    return this.setPage(t), await this._loadList(!1), this._awaitResponse();
+  }
+  async _awaitResponse() {
+    const t = Object.values(this.navigationEmojis), e = this.clientAssets.message.channel, i = (e, i) => {
+      const s = !!this._enabled("all") && (!this._disabledNavigationEmojiValues.length || this._disabledNavigationEmojiValues.some((t => ![ e.emoji.name, e.emoji.id ].includes(t)))) && (t.includes(e.emoji.name) || t.includes(e.emoji.id)) || e.emoji.name in this.functionEmojis || e.emoji.id in this.functionEmojis;
+      return this.authorizedUsers.length ? this.authorizedUsers.includes(i.id) && s : !i.bot && s;
+    }, s = this.clientAssets.message;
+    try {
+      const t = (await s.awaitReactions(i, {
+        max: 1,
+        time: this.timeout,
+        errors: [ "time" ]
+      })).first(), a = t.users.cache.last(), n = [ t.emoji.name, t.emoji.id ];
+      if (this.listenerCount("react") && this.emit("react", a, t.emoji), s.guild) {
+        e.permissionsFor(e.client.user).missing([ "MANAGE_MESSAGES" ]).length || await t.users.remove(a);
+      }
+      switch (n[0] || n[1]) {
+       case this.navigationEmojis.back:
+        return 1 === this.page ? this._awaitResponse() : this._loadPage("back");
+
+       case this.navigationEmojis.jump:
+        return this.pages <= 2 ? this._awaitResponse() : this._awaitResponseEx(a);
+
+       case this.navigationEmojis.forward:
+        return this.page === this.pages ? this._awaitResponse() : this._loadPage("forward");
+
+       case this.navigationEmojis.delete:
+        return await s.delete(), void (this.listenerCount("finish") && this.emit("finish", a));
+
+       default:
+        {
+          const t = this.functionEmojis[n[0]] || this.functionEmojis[n[1]];
+          try {
+            await t(a, this);
+          } catch (t) {
+            return this._cleanUp(t, s, !1, a);
+          }
+          return this._loadPage(this.page);
         }
-        if (invalid.length)
-            throw new TypeError(`Cannot invoke PaginationEmbed class with invalid navigation emoji(s): ${invalid.join(', ')}.`);
-        this.disabledNavigationEmojis = verified;
-        return this;
+      }
+    } catch (t) {
+      return this._cleanUp(t, s);
     }
-    /**
-     * Sets whether to set function emojis after navigation emojis.
-     * @param boolean - Set function emojis after navigation emojis?
-     */
-    setEmojisFunctionAfterNavigation(boolean) {
-        if (typeof boolean !== 'boolean')
-            throw new TypeError('setEmojisFunctionAfterNavigation() only accepts boolean type.');
-        this.emojisFunctionAfterNavigation = boolean;
-        return this;
+  }
+  async _cleanUp(t, e, i = !0, s) {
+    const a = this.clientAssets.message.channel;
+    if (this.deleteOnTimeout && e.deletable && (await e.delete(), e.deleted = !0), e.guild && !e.deleted) {
+      a.permissionsFor(a.client.user).missing([ "MANAGE_MESSAGES" ]).length || await e.reactions.removeAll();
     }
-    /**
-     * Sets the emojis used for function emojis.
-     *
-     * ### Example
-     * ```js
-     *  <PaginationEmbed>.setFunctionEmojis({
-     *    '🔄': (user, instance) => {
-     *      const field = instance.embed.fields[0];
-     *
-     *      if (field.name === 'Name')
-     *        field.name = user.tag;
-     *      else
-     *        field.name = 'Name';
-     *    }
-     *  });
-     * ```
-     * @param emojis - An object containing customised emojis to use as function emojis.
-     */
-    setFunctionEmojis(emojis) {
-        for (const emoji of Object.keys(emojis)) {
-            const fn = emojis[emoji];
-            this.addFunctionEmoji(emoji, fn);
-        }
-        return this;
+    if (t instanceof Error) return void (this.listenerCount("error") && this.emit("error", t));
+    const n = i ? "expire" : "finish";
+    this.listenerCount(n) && this.emit(n, s);
+  }
+  async _awaitResponseEx(t) {
+    const e = [ "0", "cancel" ], i = i => {
+      const s = parseInt(i.content);
+      return i.author.id === t.id && (!isNaN(Number(i.content)) && s !== this.page && s >= 1 && s <= this.pages || e.includes(i.content.toLowerCase()));
+    }, s = this.clientAssets.message.channel, a = await s.send(this.clientAssets.prompt.replace(/\{\{user\}\}/g, t.toString()));
+    try {
+      const t = (await s.awaitMessages(i, {
+        max: 1,
+        time: this.timeout,
+        errors: [ "time" ]
+      })).first(), n = t.content, o = s.permissionsFor(s.client.user).missing([ "MANAGE_MESSAGES" ]);
+      return this.clientAssets.message.deleted ? void (this.listenerCount("error") && this.emit("error", new Error("Client's message was deleted before being processed."))) : (await a.delete(), 
+      t.deletable && (o.length || await t.delete()), e.includes(n) ? this._awaitResponse() : this._loadPage(parseInt(n)));
+    } catch (t) {
+      if (a.deletable && await a.delete(), t instanceof Error) return void (this.listenerCount("error") && this.emit("error", t));
+      this.listenerCount("expire") && this.emit("expire");
     }
-    /**
-     * Sets the emojis used for navigation emojis.
-     * @param emojis - An object containing customised emojis to use as navigation emojis.
-     */
-    setNavigationEmojis(emojis) {
-        Object.assign(this.navigationEmojis, emojis);
-        return this;
-    }
-    /**
-     * Sets to jump to a certain page upon calling PaginationEmbed.build().
-     * @param page - The page number to jump to.
-     */
-    setPage(page) {
-        const isString = typeof page === 'string';
-        if (!(!isNaN(page) || isString))
-            throw new TypeError('setPage() only accepts number/string type.');
-        const navigator = page === 'back'
-            ? this.page === 1 ? this.page : this.page - 1
-            : this.page === this.pages ? this.pages : this.page + 1;
-        this.page = isString ? navigator : page;
-        return this;
-    }
-    /**
-     * Sets the time for awaiting a user action before timeout in ms.
-     * @param timeout Timeout value in ms.
-     */
-    setTimeout(timeout) {
-        if (typeof timeout !== 'number')
-            throw new TypeError('setTimeout() only accepts number type.');
-        this.timeout = timeout;
-        return this;
-    }
-    /**
-     * Sets the page indicator formatting function and placement.
-     * @param enabled - Whether to show page indicator.
-     *   Pass `footer` to display the indicator in embed's footer text (replaces existing text) instead.
-     * @param fn - Function for indicator formatting.
-     */
-    setPageIndicator(enabled, fn) {
-        if (typeof enabled === 'boolean' || (typeof enabled === 'string' && enabled === 'footer'))
-            this.usePageIndicator = enabled;
-        else
-            throw new TypeError('setPageIndicator()\'s `enabled` parameter only accepts boolean/string type.');
-        if (fn) {
-            const allowedTypes = ['text', 'textcompact', 'circle', 'hybrid'];
-            if (typeof fn === 'string' && allowedTypes.includes(fn))
-                this._pageIndicator = this._defaultPageIndicators[fn];
-            else if (typeof fn === 'function')
-                this._pageIndicator = fn;
-            else
-                throw new TypeError('setPageIndicator()\'s `fn` parameter only accepts function/string type.');
-        }
-        return this;
-    }
-    /**
-     * Sets whether the client's message will be deleted upon timeout.
-     * @param deleteOnTimeout - Delete client's message upon timeout?
-     */
-    setDeleteOnTimeout(boolean) {
-        if (typeof boolean !== 'boolean')
-            throw new TypeError('deleteOnTimeout() only accepts boolean type.');
-        this.deleteOnTimeout = boolean;
-        return this;
-    }
-    /**
-     * Evaluates the constructor and the client.
-     * @ignore
-     */
-    async _verify() {
-        this.setClientAssets(this.clientAssets);
-        if (!this.channel)
-            throw new Error('Cannot invoke PaginationEmbed class without a channel object set.');
-        if (!(this.page >= 1 && this.page <= this.pages))
-            throw new RangeError(`Page number is out of bounds. Max pages: ${this.pages}`);
-        return this._checkPermissions();
-    }
-    /**
-     * Checks the permissions of the client before sending the embed.
-     * @ignore
-     */
-    async _checkPermissions() {
-        const channel = this.channel;
-        if (channel.guild) {
-            const missing = channel
-                .permissionsFor(channel.client.user)
-                .missing(['ADD_REACTIONS', 'EMBED_LINKS', 'VIEW_CHANNEL', 'SEND_MESSAGES']);
-            if (missing.length)
-                throw new Error(`Cannot invoke PaginationEmbed class without required permissions: ${missing.join(', ')}`);
-        }
-        return true;
-    }
-    /**
-     * Returns whether the given navigation emoji is enabled.
-     * @param emoji The navigation emoji to search.
-     */
-    _enabled(emoji) {
-        return this.disabledNavigationEmojis.includes('all')
-            ? false
-            : !this.disabledNavigationEmojis.includes(emoji);
-    }
-    /** Deploys emoji reacts for the message sent by the client. */
-    async _drawEmojis() {
-        if (this.emojisFunctionAfterNavigation) {
-            await this._drawNavigationEmojis();
-            await this._drawFunctionEmojis();
-        }
-        else {
-            await this._drawFunctionEmojis();
-            await this._drawNavigationEmojis();
-        }
-        if (this.listenerCount('start'))
-            this.emit('start');
-        return this._awaitResponse();
-    }
-    /** Deploys function emojis. */
-    async _drawFunctionEmojis() {
-        if (Object.keys(this.functionEmojis).length)
-            for (const emoji of Object.keys(this.functionEmojis))
-                await this.clientAssets.message.react(emoji);
-    }
-    /** Deploys navigation emojis. */
-    async _drawNavigationEmojis() {
-        if (this._enabled('back') && this.pages > 1)
-            await this.clientAssets.message.react(this.navigationEmojis.back);
-        if (this._enabled('jump') && this.pages > 2)
-            await this.clientAssets.message.react(this.navigationEmojis.jump);
-        if (this._enabled('forward') && this.pages > 1)
-            await this.clientAssets.message.react(this.navigationEmojis.forward);
-        if (this._enabled('delete'))
-            await this.clientAssets.message.react(this.navigationEmojis.delete);
-    }
-    /**
-     * Helper for intialising the MessageEmbed.
-     * [For sub-class] Initialises the MessageEmbed.
-     * @param callNavigation - Whether to call _drawEmojis().
-     * @ignore
-     */
-    _loadList(callNavigation = true) {
-        if (callNavigation)
-            return this._drawEmojis();
-    }
-    /**
-     * Calls PaginationEmbed.setPage() and then executes `_loadList()` and `_awaitResponse()`.
-     * @param param - The page number to jump to.
-     */
-    async _loadPage(param = 1) {
-        this.setPage(param);
-        await this._loadList(false);
-        return this._awaitResponse();
-    }
-    /** Awaits the reaction from the user(s). */
-    async _awaitResponse() {
-        const emojis = Object.values(this.navigationEmojis);
-        const channel = this.clientAssets.message.channel;
-        const filter = (r, u) => {
-            const enabledEmoji = this._enabled('all')
-                ? !this._disabledNavigationEmojiValues.length
-                    || this._disabledNavigationEmojiValues.some(e => ![r.emoji.name, r.emoji.id].includes(e))
-                : false;
-            const passedEmoji = (enabledEmoji && (emojis.includes(r.emoji.name) || emojis.includes(r.emoji.id))) ||
-                r.emoji.name in this.functionEmojis || r.emoji.id in this.functionEmojis;
-            if (this.authorizedUsers.length)
-                return this.authorizedUsers.includes(u.id) && passedEmoji;
-            return !u.bot && passedEmoji;
-        };
-        const clientMessage = this.clientAssets.message;
-        try {
-            const responses = await clientMessage.awaitReactions(filter, { max: 1, time: this.timeout, errors: ['time'] });
-            const response = responses.first();
-            const user = response.users.cache.last();
-            const emoji = [response.emoji.name, response.emoji.id];
-            if (this.listenerCount('react'))
-                this.emit('react', user, response.emoji);
-            if (clientMessage.guild) {
-                const missing = channel
-                    .permissionsFor(channel.client.user)
-                    .missing(['MANAGE_MESSAGES']);
-                if (!missing.length)
-                    await response.users.remove(user);
-            }
-            switch (emoji[0] || emoji[1]) {
-                case this.navigationEmojis.back:
-                    if (this.page === 1)
-                        return this._awaitResponse();
-                    return this._loadPage('back');
-                case this.navigationEmojis.jump:
-                    if (this.pages <= 2)
-                        return this._awaitResponse();
-                    return this._awaitResponseEx(user);
-                case this.navigationEmojis.forward:
-                    if (this.page === this.pages)
-                        return this._awaitResponse();
-                    return this._loadPage('forward');
-                case this.navigationEmojis.delete:
-                    await clientMessage.delete();
-                    if (this.listenerCount('finish'))
-                        this.emit('finish', user);
-                    return;
-                default: {
-                    const cb = this.functionEmojis[emoji[0]] || this.functionEmojis[emoji[1]];
-                    try {
-                        await cb(user, this);
-                    }
-                    catch (err) {
-                        return this._cleanUp(err, clientMessage, false, user);
-                    }
-                    return this._loadPage(this.page);
-                }
-            }
-        }
-        catch (err) {
-            return this._cleanUp(err, clientMessage);
-        }
-    }
-    /**
-     * Only used for `_awaitResponse`:
-     * Deletes the client's message, and emits either `error` or `finish` event depending on the passed parameters.
-     * @param err The error object.
-     * @param clientMessage The client's message.
-     * @param expired Whether the clean up is for `expired` event.
-     * @param user The user object (only for `finish` event).
-     */
-    async _cleanUp(err, clientMessage, expired = true, user) {
-        const channel = this.clientAssets.message.channel;
-        if (this.deleteOnTimeout && clientMessage.deletable) {
-            await clientMessage.delete();
-            clientMessage.deleted = true;
-        }
-        if (clientMessage.guild && !clientMessage.deleted) {
-            const missing = channel
-                .permissionsFor(channel.client.user)
-                .missing(['MANAGE_MESSAGES']);
-            if (!missing.length)
-                await clientMessage.reactions.removeAll();
-        }
-        if (err instanceof Error) {
-            if (this.listenerCount('error'))
-                this.emit('error', err);
-            return;
-        }
-        const eventType = expired ? 'expire' : 'finish';
-        if (this.listenerCount(eventType))
-            this.emit(eventType, user);
-    }
-    /**
-     * Awaits the custom page input from the user.
-     * @param user - The user who reacted to jump on a certain page.
-     */
-    async _awaitResponseEx(user) {
-        const cancel = ['0', 'cancel'];
-        const filter = (m) => {
-            const supposedPage = parseInt(m.content);
-            return (m.author.id === user.id && ((!isNaN(Number(m.content)) && supposedPage !== this.page && supposedPage >= 1 && supposedPage <= this.pages)
-                || cancel.includes(m.content.toLowerCase())));
-        };
-        const channel = this.clientAssets.message.channel;
-        const prompt = await channel
-            .send(this.clientAssets.prompt.replace(/\{\{user\}\}/g, user.toString()));
-        try {
-            const responses = await channel.awaitMessages(filter, { max: 1, time: this.timeout, errors: ['time'] });
-            const response = responses.first();
-            const content = response.content;
-            const missing = channel.permissionsFor(channel.client.user)
-                .missing(['MANAGE_MESSAGES']);
-            if (this.clientAssets.message.deleted) {
-                if (this.listenerCount('error'))
-                    this.emit('error', new Error(MESSAGE_DELETED));
-                return;
-            }
-            await prompt.delete();
-            if (response.deletable)
-                if (!missing.length) {
-                    await response.delete();
-                }
-            if (cancel.includes(content))
-                return this._awaitResponse();
-            return this._loadPage(parseInt(content));
-        }
-        catch (c) {
-            if (prompt.deletable)
-                await prompt.delete();
-            if (c instanceof Error) {
-                if (this.listenerCount('error'))
-                    this.emit('error', c);
-                return;
-            }
-            if (this.listenerCount('expire'))
-                this.emit('expire');
-        }
-    }
+  }
 }
-exports.PaginationEmbed = PaginationEmbed;
+
+exports.PaginationEmbed = e;

--- a/bin/base/index.js
+++ b/bin/base/index.js
@@ -1,220 +1,495 @@
 "use strict";
-
-Object.defineProperty(exports, "__esModule", {
-  value: !0
-});
-
-const t = require("events"), e = "Client's message was deleted before being processed.";
-
-exports.PaginationEmbed = class extends t.EventEmitter {
-  constructor() {
-    super(), this.authorizedUsers = [], this.channel = null, this.clientAssets = {}, 
-    this.usePageIndicator = !1, this.deleteOnTimeout = !1, this.page = 1, this.timeout = 3e4, 
-    this.navigationEmojis = {
-      back: "◀",
-      jump: "↗",
-      forward: "▶",
-      delete: "🗑"
-    }, this.functionEmojis = {}, this.disabledNavigationEmojis = [], this.emojisFunctionAfterNavigation = !1, 
-    this.pages = null, this._disabledNavigationEmojiValues = [], this._defaultNavigationEmojis = {
-      back: "◀",
-      jump: "↗",
-      forward: "▶",
-      delete: "🗑"
-    };
-    const t = (t, e) => `${"○ ".repeat(t - 1)}● ${"○ ".repeat(e - t)}`.trim();
-    this._defaultPageIndicators = {
-      text: (t, e) => `Page ${t} of ${e}`,
-      textcompact: (t, e) => `${t}/${e}`,
-      circle: (e, i) => t(e, i),
-      hybrid: (e, i) => `[${e}/${i}] ${t(e, i)}`
-    }, this._pageIndicator = this._defaultPageIndicators.text;
-  }
-  get pageIndicator() {
-    return this._pageIndicator(this.page, this.pages);
-  }
-  build() {
-    throw new Error("Cannot invoke this class. Invoke with [PaginationEmbed.Embeds] or [PaginationEmbed.FieldsEmbed] instead.");
-  }
-  addFunctionEmoji(t, e) {
-    if (!(e instanceof Function)) throw new TypeError(`Callback for ${t} must be a function type.`);
-    return Object.assign(this.functionEmojis, {
-      [t]: e
-    }), this;
-  }
-  deleteFunctionEmoji(t) {
-    if (!(t in this.functionEmojis)) throw new Error(`${t} function emoji does not exist.`);
-    return delete this.functionEmojis[t], this;
-  }
-  resetEmojis() {
-    for (const t of Object.keys(this.functionEmojis)) delete this.functionEmojis[t];
-    return this.navigationEmojis = this._defaultNavigationEmojis, this;
-  }
-  setArray(t) {
-    if (!Array.isArray(t) || !Boolean(t.length)) throw new TypeError("Cannot invoke PaginationEmbed class without a valid array to paginate.");
-    return this.array = t, this;
-  }
-  setAuthorizedUsers(t) {
-    if (!Array.isArray(t) && "string" != typeof t) throw new TypeError("Cannot invoke PaginationEmbed class without a valid array.");
-    return this.authorizedUsers = Array.isArray(t) ? t : [ t ], this;
-  }
-  setChannel(t) {
-    return this.channel = t, this;
-  }
-  setClientAssets(t) {
-    if (!t) throw new TypeError("Cannot accept assets options as a non-object type.");
-    const {message: e} = t;
-    let {prompt: i} = t;
-    return i || (i = "{{user}}, To what page would you like to jump? Say `cancel` or `0` to cancel the prompt."), 
-    Object.assign(this.clientAssets, {
-      message: e,
-      prompt: i
-    }), this;
-  }
-  setDisabledNavigationEmojis(t) {
-    if (!Array.isArray(t)) throw new TypeError("Cannot invoke PaginationEmbed class without a valid array.");
-    const e = [], i = [];
-    for (const s of t) [ "back", "jump", "forward", "delete", "all" ].includes(s) ? i.push(s) : e.push(s);
-    if (e.length) throw new TypeError(`Cannot invoke PaginationEmbed class with invalid navigation emoji(s): ${e.join(", ")}.`);
-    return this.disabledNavigationEmojis = i, this;
-  }
-  setEmojisFunctionAfterNavigation(t) {
-    if ("boolean" != typeof t) throw new TypeError("setEmojisFunctionAfterNavigation() only accepts boolean type.");
-    return this.emojisFunctionAfterNavigation = t, this;
-  }
-  setFunctionEmojis(t) {
-    for (const e of Object.keys(t)) {
-      const i = t[e];
-      this.addFunctionEmoji(e, i);
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.PaginationEmbed = void 0;
+const events_1 = require("events");
+/** @ignore */
+const MESSAGE_DELETED = 'Client\'s message was deleted before being processed.';
+/**
+ * The base class for Pagination Modes. **Do not invoke**.
+ * @extends [EventEmitter](https://nodejs.org/api/events.html#events_class_eventemitter)
+ * @noInheritDoc
+ */
+class PaginationEmbed extends events_1.EventEmitter {
+    constructor() {
+        super();
+        this.authorizedUsers = [];
+        this.channel = null;
+        this.clientAssets = {};
+        this.usePageIndicator = false;
+        this.deleteOnTimeout = false;
+        this.page = 1;
+        this.timeout = 30000;
+        this.navigationEmojis = {
+            back: '◀',
+            jump: '↗',
+            forward: '▶',
+            delete: '🗑'
+        };
+        this.functionEmojis = {};
+        this.disabledNavigationEmojis = [];
+        this.emojisFunctionAfterNavigation = false;
+        this.pages = null;
+        this._disabledNavigationEmojiValues = [];
+        this._defaultNavigationEmojis = {
+            back: '◀',
+            jump: '↗',
+            forward: '▶',
+            delete: '🗑'
+        };
+        const makeCircles = (page, pages) => `${'○ '.repeat(page - 1)}● ${'○ '.repeat(pages - page)}`.trim();
+        this._defaultPageIndicators = {
+            text: (page, pages) => `Page ${page} of ${pages}`,
+            textcompact: (page, pages) => `${page}/${pages}`,
+            circle: (page, pages) => makeCircles(page, pages),
+            hybrid: (page, pages) => `[${page}/${pages}] ${makeCircles(page, pages)}`
+        };
+        this._pageIndicator = this._defaultPageIndicators.text;
     }
-    return this;
-  }
-  setNavigationEmojis(t) {
-    return Object.assign(this.navigationEmojis, t), this;
-  }
-  setPage(t) {
-    const e = "string" == typeof t;
-    if (isNaN(t) && !e) throw new TypeError("setPage() only accepts number/string type.");
-    const i = "back" === t ? 1 === this.page ? this.page : this.page - 1 : this.page === this.pages ? this.pages : this.page + 1;
-    return this.page = e ? i : t, this;
-  }
-  setTimeout(t) {
-    if ("number" != typeof t) throw new TypeError("setTimeout() only accepts number type.");
-    return this.timeout = t, this;
-  }
-  setPageIndicator(t, e) {
-    if ("boolean" != typeof t && ("string" != typeof t || "footer" !== t)) throw new TypeError("setPageIndicator()'s `enabled` parameter only accepts boolean/string type.");
-    if (this.usePageIndicator = t, e) {
-      const t = [ "text", "textcompact", "circle", "hybrid" ];
-      if ("string" == typeof e && t.includes(e)) this._pageIndicator = this._defaultPageIndicators[e]; else {
-        if ("function" != typeof e) throw new TypeError("setPageIndicator()'s `fn` parameter only accepts function/string type.");
-        this._pageIndicator = e;
-      }
+    /** The formatted page indicator. Default format: `text` */
+    get pageIndicator() {
+        return this._pageIndicator(this.page, this.pages);
     }
-    return this;
-  }
-  setDeleteOnTimeout(t) {
-    if ("boolean" != typeof t) throw new TypeError("deleteOnTimeout() only accepts boolean type.");
-    return this.deleteOnTimeout = t, this;
-  }
-  async _verify() {
-    if (this.setClientAssets(this.clientAssets), !this.channel) throw new Error("Cannot invoke PaginationEmbed class without a channel object set.");
-    if (!(this.page >= 1 && this.page <= this.pages)) throw new RangeError(`Page number is out of bounds. Max pages: ${this.pages}`);
-    return this._checkPermissions();
-  }
-  async _checkPermissions() {
-    const t = this.channel;
-    if (t.guild) {
-      const e = t.permissionsFor(t.client.user).missing([ "ADD_REACTIONS", "MANAGE_MESSAGES", "EMBED_LINKS", "VIEW_CHANNEL", "SEND_MESSAGES" ]);
-      if (e.length) throw new Error(`Cannot invoke PaginationEmbed class without required permissions: ${e.join(", ")}`);
+    build() {
+        throw new Error('Cannot invoke this class. Invoke with [PaginationEmbed.Embeds] or [PaginationEmbed.FieldsEmbed] instead.');
     }
-    return !0;
-  }
-  _enabled(t) {
-    return !this.disabledNavigationEmojis.includes("all") && !this.disabledNavigationEmojis.includes(t);
-  }
-  async _drawEmojis() {
-    return this.emojisFunctionAfterNavigation ? (await this._drawNavigationEmojis(), 
-    await this._drawFunctionEmojis()) : (await this._drawFunctionEmojis(), await this._drawNavigationEmojis()), 
-    this.listenerCount("start") && this.emit("start"), this._awaitResponse();
-  }
-  async _drawFunctionEmojis() {
-    if (Object.keys(this.functionEmojis).length) for (const t of Object.keys(this.functionEmojis)) await this.clientAssets.message.react(t);
-  }
-  async _drawNavigationEmojis() {
-    this._enabled("back") && this.pages > 1 && await this.clientAssets.message.react(this.navigationEmojis.back), 
-    this._enabled("jump") && this.pages > 2 && await this.clientAssets.message.react(this.navigationEmojis.jump), 
-    this._enabled("forward") && this.pages > 1 && await this.clientAssets.message.react(this.navigationEmojis.forward), 
-    this._enabled("delete") && await this.clientAssets.message.react(this.navigationEmojis.delete);
-  }
-  _loadList(t = !0) {
-    if (t) return this._drawEmojis();
-  }
-  async _loadPage(t = 1) {
-    return this.setPage(t), await this._loadList(!1), this._awaitResponse();
-  }
-  async _awaitResponse() {
-    const t = Object.values(this.navigationEmojis), e = (e, i) => {
-      const s = !!this._enabled("all") && (!this._disabledNavigationEmojiValues.length || this._disabledNavigationEmojiValues.some(t => ![ e.emoji.name, e.emoji.id ].includes(t))) && (t.includes(e.emoji.name) || t.includes(e.emoji.id)) || e.emoji.name in this.functionEmojis || e.emoji.id in this.functionEmojis;
-      return this.authorizedUsers.length ? this.authorizedUsers.includes(i.id) && s : !i.bot && s;
-    }, i = this.clientAssets.message;
-    try {
-      const t = (await i.awaitReactions(e, {
-        max: 1,
-        time: this.timeout,
-        errors: [ "time" ]
-      })).first(), s = t.users.cache.last(), a = [ t.emoji.name, t.emoji.id ];
-      switch (this.listenerCount("react") && this.emit("react", s, t.emoji), i.guild && await t.users.remove(s), 
-      a[0] || a[1]) {
-       case this.navigationEmojis.back:
-        return 1 === this.page ? this._awaitResponse() : this._loadPage("back");
-
-       case this.navigationEmojis.jump:
-        return this.pages <= 2 ? this._awaitResponse() : this._awaitResponseEx(s);
-
-       case this.navigationEmojis.forward:
-        return this.page === this.pages ? this._awaitResponse() : this._loadPage("forward");
-
-       case this.navigationEmojis.delete:
-        return await i.delete(), void (this.listenerCount("finish") && this.emit("finish", s));
-
-       default:
-        {
-          const t = this.functionEmojis[a[0]] || this.functionEmojis[a[1]];
-          try {
-            await t(s, this);
-          } catch (t) {
-            return this._cleanUp(t, i, !1, s);
-          }
-          return this._loadPage(this.page);
+    /**
+     * Adds a function emoji to the embed.
+     *
+     * ### Example
+     * ```js
+     *  <PaginationEmbed>.addFunctionEmoji('🅱', (_, instance) => {
+     *    const field = instance.embed.fields[0];
+     *
+     *    if (field.name.includes('🅱'))
+     *      field.name = 'Name';
+     *    else
+     *      field.name = 'Na🅱e';
+     *  });
+     * ```
+     * @param emoji - The emoji to use as the function's emoji.
+     * @param callback - The function to call upon pressing the function emoji.
+     */
+    addFunctionEmoji(emoji, callback) {
+        if (!(callback instanceof Function))
+            throw new TypeError(`Callback for ${emoji} must be a function type.`);
+        Object.assign(this.functionEmojis, { [emoji]: callback });
+        return this;
+    }
+    /**
+     * Deletes a function emoji.
+     * @param emoji - The emoji key to delete.
+     */
+    deleteFunctionEmoji(emoji) {
+        if (!(emoji in this.functionEmojis))
+            throw new Error(`${emoji} function emoji does not exist.`);
+        delete this.functionEmojis[emoji];
+        return this;
+    }
+    /** Deletes all function emojis, and then re-enables all navigation emojis. */
+    resetEmojis() {
+        for (const emoji of Object.keys(this.functionEmojis))
+            delete this.functionEmojis[emoji];
+        this.navigationEmojis = this._defaultNavigationEmojis;
+        return this;
+    }
+    /**
+     * Sets the array of elements to paginate. This must be called first before any other methods.
+     * @param array - An array of elements to paginate.
+     */
+    setArray(array) {
+        const isValidArray = Array.isArray(array) && Boolean(array.length);
+        if (!isValidArray)
+            throw new TypeError('Cannot invoke PaginationEmbed class without a valid array to paginate.');
+        this.array = array;
+        return this;
+    }
+    /**
+     * Set the authorized users to navigate the pages.
+     * @param users - A user ID or an array of user IDs.
+     */
+    setAuthorizedUsers(users) {
+        if (!(Array.isArray(users) || typeof users === 'string'))
+            throw new TypeError('Cannot invoke PaginationEmbed class without a valid array.');
+        this.authorizedUsers = Array.isArray(users) ? users : [users];
+        return this;
+    }
+    /**
+     * The channel where to send the embed.
+     * @param channel - The channel object.
+     */
+    setChannel(channel) {
+        this.channel = channel;
+        return this;
+    }
+    /**
+     * Sets the settings for assets for the client.
+     * @param assets - The assets for the client.
+     */
+    setClientAssets(assets) {
+        if (!assets)
+            throw new TypeError('Cannot accept assets options as a non-object type.');
+        const { message } = assets;
+        let { prompt } = assets;
+        if (!prompt)
+            prompt = '{{user}}, To what page would you like to jump? Say `cancel` or `0` to cancel the prompt.';
+        Object.assign(this.clientAssets, { message, prompt });
+        return this;
+    }
+    /**
+     * Sets the disabled navigation emojis.
+     *
+     * ### Example
+     * ```js
+     *  // Disable specific navigation emojis
+     *  <PaginationEmbed>.setDisabledNavigationEmojis(['delete', 'jump']);
+     *
+     *  // Disable all navigation emojis
+     *  <PaginationEmbed>.setDisabledNavigationEmojis(['all']);
+     * ```
+     *
+     * @param emojis  - An array of navigation emojis to disable.
+     */
+    setDisabledNavigationEmojis(emojis) {
+        if (!Array.isArray(emojis))
+            throw new TypeError('Cannot invoke PaginationEmbed class without a valid array.');
+        const invalid = [];
+        const verified = [];
+        for (const emoji of emojis) {
+            const validEmojis = ['back', 'jump', 'forward', 'delete', 'all'];
+            if (validEmojis.includes(emoji))
+                verified.push(emoji);
+            else
+                invalid.push(emoji);
         }
-      }
-    } catch (t) {
-      return this._cleanUp(t, i);
+        if (invalid.length)
+            throw new TypeError(`Cannot invoke PaginationEmbed class with invalid navigation emoji(s): ${invalid.join(', ')}.`);
+        this.disabledNavigationEmojis = verified;
+        return this;
     }
-  }
-  async _cleanUp(t, e, i = !0, s) {
-    if (this.deleteOnTimeout && e.deletable && (await e.delete(), e.deleted = !0), e.guild && !e.deleted && await e.reactions.removeAll(), 
-    t instanceof Error) return void (this.listenerCount("error") && this.emit("error", t));
-    const a = i ? "expire" : "finish";
-    this.listenerCount(a) && this.emit(a, s);
-  }
-  async _awaitResponseEx(t) {
-    const i = [ "0", "cancel" ], s = e => {
-      const s = parseInt(e.content);
-      return e.author.id === t.id && (!isNaN(Number(e.content)) && s !== this.page && s >= 1 && s <= this.pages || i.includes(e.content.toLowerCase()));
-    }, a = this.clientAssets.message.channel, n = await a.send(this.clientAssets.prompt.replace(/\{\{user\}\}/g, t.toString()));
-    try {
-      const t = (await a.awaitMessages(s, {
-        max: 1,
-        time: this.timeout,
-        errors: [ "time" ]
-      })).first(), o = t.content;
-      return this.clientAssets.message.deleted ? void (this.listenerCount("error") && this.emit("error", new Error(e))) : (await n.delete(), 
-      t.deletable && await t.delete(), i.includes(o) ? this._awaitResponse() : this._loadPage(parseInt(o)));
-    } catch (t) {
-      if (n.deletable && await n.delete(), t instanceof Error) return void (this.listenerCount("error") && this.emit("error", t));
-      this.listenerCount("expire") && this.emit("expire");
+    /**
+     * Sets whether to set function emojis after navigation emojis.
+     * @param boolean - Set function emojis after navigation emojis?
+     */
+    setEmojisFunctionAfterNavigation(boolean) {
+        if (typeof boolean !== 'boolean')
+            throw new TypeError('setEmojisFunctionAfterNavigation() only accepts boolean type.');
+        this.emojisFunctionAfterNavigation = boolean;
+        return this;
     }
-  }
-};
+    /**
+     * Sets the emojis used for function emojis.
+     *
+     * ### Example
+     * ```js
+     *  <PaginationEmbed>.setFunctionEmojis({
+     *    '🔄': (user, instance) => {
+     *      const field = instance.embed.fields[0];
+     *
+     *      if (field.name === 'Name')
+     *        field.name = user.tag;
+     *      else
+     *        field.name = 'Name';
+     *    }
+     *  });
+     * ```
+     * @param emojis - An object containing customised emojis to use as function emojis.
+     */
+    setFunctionEmojis(emojis) {
+        for (const emoji of Object.keys(emojis)) {
+            const fn = emojis[emoji];
+            this.addFunctionEmoji(emoji, fn);
+        }
+        return this;
+    }
+    /**
+     * Sets the emojis used for navigation emojis.
+     * @param emojis - An object containing customised emojis to use as navigation emojis.
+     */
+    setNavigationEmojis(emojis) {
+        Object.assign(this.navigationEmojis, emojis);
+        return this;
+    }
+    /**
+     * Sets to jump to a certain page upon calling PaginationEmbed.build().
+     * @param page - The page number to jump to.
+     */
+    setPage(page) {
+        const isString = typeof page === 'string';
+        if (!(!isNaN(page) || isString))
+            throw new TypeError('setPage() only accepts number/string type.');
+        const navigator = page === 'back'
+            ? this.page === 1 ? this.page : this.page - 1
+            : this.page === this.pages ? this.pages : this.page + 1;
+        this.page = isString ? navigator : page;
+        return this;
+    }
+    /**
+     * Sets the time for awaiting a user action before timeout in ms.
+     * @param timeout Timeout value in ms.
+     */
+    setTimeout(timeout) {
+        if (typeof timeout !== 'number')
+            throw new TypeError('setTimeout() only accepts number type.');
+        this.timeout = timeout;
+        return this;
+    }
+    /**
+     * Sets the page indicator formatting function and placement.
+     * @param enabled - Whether to show page indicator.
+     *   Pass `footer` to display the indicator in embed's footer text (replaces existing text) instead.
+     * @param fn - Function for indicator formatting.
+     */
+    setPageIndicator(enabled, fn) {
+        if (typeof enabled === 'boolean' || (typeof enabled === 'string' && enabled === 'footer'))
+            this.usePageIndicator = enabled;
+        else
+            throw new TypeError('setPageIndicator()\'s `enabled` parameter only accepts boolean/string type.');
+        if (fn) {
+            const allowedTypes = ['text', 'textcompact', 'circle', 'hybrid'];
+            if (typeof fn === 'string' && allowedTypes.includes(fn))
+                this._pageIndicator = this._defaultPageIndicators[fn];
+            else if (typeof fn === 'function')
+                this._pageIndicator = fn;
+            else
+                throw new TypeError('setPageIndicator()\'s `fn` parameter only accepts function/string type.');
+        }
+        return this;
+    }
+    /**
+     * Sets whether the client's message will be deleted upon timeout.
+     * @param deleteOnTimeout - Delete client's message upon timeout?
+     */
+    setDeleteOnTimeout(boolean) {
+        if (typeof boolean !== 'boolean')
+            throw new TypeError('deleteOnTimeout() only accepts boolean type.');
+        this.deleteOnTimeout = boolean;
+        return this;
+    }
+    /**
+     * Evaluates the constructor and the client.
+     * @ignore
+     */
+    async _verify() {
+        this.setClientAssets(this.clientAssets);
+        if (!this.channel)
+            throw new Error('Cannot invoke PaginationEmbed class without a channel object set.');
+        if (!(this.page >= 1 && this.page <= this.pages))
+            throw new RangeError(`Page number is out of bounds. Max pages: ${this.pages}`);
+        return this._checkPermissions();
+    }
+    /**
+     * Checks the permissions of the client before sending the embed.
+     * @ignore
+     */
+    async _checkPermissions() {
+        const channel = this.channel;
+        if (channel.guild) {
+            const missing = channel
+                .permissionsFor(channel.client.user)
+                .missing(['ADD_REACTIONS', 'EMBED_LINKS', 'VIEW_CHANNEL', 'SEND_MESSAGES']);
+            if (missing.length)
+                throw new Error(`Cannot invoke PaginationEmbed class without required permissions: ${missing.join(', ')}`);
+        }
+        return true;
+    }
+    /**
+     * Returns whether the given navigation emoji is enabled.
+     * @param emoji The navigation emoji to search.
+     */
+    _enabled(emoji) {
+        return this.disabledNavigationEmojis.includes('all')
+            ? false
+            : !this.disabledNavigationEmojis.includes(emoji);
+    }
+    /** Deploys emoji reacts for the message sent by the client. */
+    async _drawEmojis() {
+        if (this.emojisFunctionAfterNavigation) {
+            await this._drawNavigationEmojis();
+            await this._drawFunctionEmojis();
+        }
+        else {
+            await this._drawFunctionEmojis();
+            await this._drawNavigationEmojis();
+        }
+        if (this.listenerCount('start'))
+            this.emit('start');
+        return this._awaitResponse();
+    }
+    /** Deploys function emojis. */
+    async _drawFunctionEmojis() {
+        if (Object.keys(this.functionEmojis).length)
+            for (const emoji of Object.keys(this.functionEmojis))
+                await this.clientAssets.message.react(emoji);
+    }
+    /** Deploys navigation emojis. */
+    async _drawNavigationEmojis() {
+        if (this._enabled('back') && this.pages > 1)
+            await this.clientAssets.message.react(this.navigationEmojis.back);
+        if (this._enabled('jump') && this.pages > 2)
+            await this.clientAssets.message.react(this.navigationEmojis.jump);
+        if (this._enabled('forward') && this.pages > 1)
+            await this.clientAssets.message.react(this.navigationEmojis.forward);
+        if (this._enabled('delete'))
+            await this.clientAssets.message.react(this.navigationEmojis.delete);
+    }
+    /**
+     * Helper for intialising the MessageEmbed.
+     * [For sub-class] Initialises the MessageEmbed.
+     * @param callNavigation - Whether to call _drawEmojis().
+     * @ignore
+     */
+    _loadList(callNavigation = true) {
+        if (callNavigation)
+            return this._drawEmojis();
+    }
+    /**
+     * Calls PaginationEmbed.setPage() and then executes `_loadList()` and `_awaitResponse()`.
+     * @param param - The page number to jump to.
+     */
+    async _loadPage(param = 1) {
+        this.setPage(param);
+        await this._loadList(false);
+        return this._awaitResponse();
+    }
+    /** Awaits the reaction from the user(s). */
+    async _awaitResponse() {
+        const emojis = Object.values(this.navigationEmojis);
+        const channel = this.clientAssets.message.channel;
+        const filter = (r, u) => {
+            const enabledEmoji = this._enabled('all')
+                ? !this._disabledNavigationEmojiValues.length
+                    || this._disabledNavigationEmojiValues.some(e => ![r.emoji.name, r.emoji.id].includes(e))
+                : false;
+            const passedEmoji = (enabledEmoji && (emojis.includes(r.emoji.name) || emojis.includes(r.emoji.id))) ||
+                r.emoji.name in this.functionEmojis || r.emoji.id in this.functionEmojis;
+            if (this.authorizedUsers.length)
+                return this.authorizedUsers.includes(u.id) && passedEmoji;
+            return !u.bot && passedEmoji;
+        };
+        const clientMessage = this.clientAssets.message;
+        try {
+            const responses = await clientMessage.awaitReactions(filter, { max: 1, time: this.timeout, errors: ['time'] });
+            const response = responses.first();
+            const user = response.users.cache.last();
+            const emoji = [response.emoji.name, response.emoji.id];
+            if (this.listenerCount('react'))
+                this.emit('react', user, response.emoji);
+            if (clientMessage.guild) {
+                const missing = channel
+                    .permissionsFor(channel.client.user)
+                    .missing(['MANAGE_MESSAGES']);
+                if (!missing.length)
+                    await response.users.remove(user);
+            }
+            switch (emoji[0] || emoji[1]) {
+                case this.navigationEmojis.back:
+                    if (this.page === 1)
+                        return this._awaitResponse();
+                    return this._loadPage('back');
+                case this.navigationEmojis.jump:
+                    if (this.pages <= 2)
+                        return this._awaitResponse();
+                    return this._awaitResponseEx(user);
+                case this.navigationEmojis.forward:
+                    if (this.page === this.pages)
+                        return this._awaitResponse();
+                    return this._loadPage('forward');
+                case this.navigationEmojis.delete:
+                    await clientMessage.delete();
+                    if (this.listenerCount('finish'))
+                        this.emit('finish', user);
+                    return;
+                default: {
+                    const cb = this.functionEmojis[emoji[0]] || this.functionEmojis[emoji[1]];
+                    try {
+                        await cb(user, this);
+                    }
+                    catch (err) {
+                        return this._cleanUp(err, clientMessage, false, user);
+                    }
+                    return this._loadPage(this.page);
+                }
+            }
+        }
+        catch (err) {
+            return this._cleanUp(err, clientMessage);
+        }
+    }
+    /**
+     * Only used for `_awaitResponse`:
+     * Deletes the client's message, and emits either `error` or `finish` event depending on the passed parameters.
+     * @param err The error object.
+     * @param clientMessage The client's message.
+     * @param expired Whether the clean up is for `expired` event.
+     * @param user The user object (only for `finish` event).
+     */
+    async _cleanUp(err, clientMessage, expired = true, user) {
+        const channel = this.clientAssets.message.channel;
+        if (this.deleteOnTimeout && clientMessage.deletable) {
+            await clientMessage.delete();
+            clientMessage.deleted = true;
+        }
+        if (clientMessage.guild && !clientMessage.deleted) {
+            const missing = channel
+                .permissionsFor(channel.client.user)
+                .missing(['MANAGE_MESSAGES']);
+            if (!missing.length)
+                await clientMessage.reactions.removeAll();
+        }
+        if (err instanceof Error) {
+            if (this.listenerCount('error'))
+                this.emit('error', err);
+            return;
+        }
+        const eventType = expired ? 'expire' : 'finish';
+        if (this.listenerCount(eventType))
+            this.emit(eventType, user);
+    }
+    /**
+     * Awaits the custom page input from the user.
+     * @param user - The user who reacted to jump on a certain page.
+     */
+    async _awaitResponseEx(user) {
+        const cancel = ['0', 'cancel'];
+        const filter = (m) => {
+            const supposedPage = parseInt(m.content);
+            return (m.author.id === user.id && ((!isNaN(Number(m.content)) && supposedPage !== this.page && supposedPage >= 1 && supposedPage <= this.pages)
+                || cancel.includes(m.content.toLowerCase())));
+        };
+        const channel = this.clientAssets.message.channel;
+        const prompt = await channel
+            .send(this.clientAssets.prompt.replace(/\{\{user\}\}/g, user.toString()));
+        try {
+            const responses = await channel.awaitMessages(filter, { max: 1, time: this.timeout, errors: ['time'] });
+            const response = responses.first();
+            const content = response.content;
+            const missing = channel.permissionsFor(channel.client.user)
+                .missing(['MANAGE_MESSAGES']);
+            if (this.clientAssets.message.deleted) {
+                if (this.listenerCount('error'))
+                    this.emit('error', new Error(MESSAGE_DELETED));
+                return;
+            }
+            await prompt.delete();
+            if (response.deletable)
+                if (!missing.length) {
+                    await response.delete();
+                }
+            if (cancel.includes(content))
+                return this._awaitResponse();
+            return this._loadPage(parseInt(content));
+        }
+        catch (c) {
+            if (prompt.deletable)
+                await prompt.delete();
+            if (c instanceof Error) {
+                if (this.listenerCount('error'))
+                    this.emit('error', c);
+                return;
+            }
+            if (this.listenerCount('expire'))
+                this.emit('expire');
+        }
+    }
+}
+exports.PaginationEmbed = PaginationEmbed;

--- a/bin/index.js
+++ b/bin/index.js
@@ -1,18 +1,19 @@
 "use strict";
-var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
-    if (k2 === undefined) k2 = k;
-    Object.defineProperty(o, k2, { enumerable: true, get: function() { return m[k]; } });
-}) : (function(o, m, k, k2) {
-    if (k2 === undefined) k2 = k;
-    o[k2] = m[k];
-}));
-var __exportStar = (this && this.__exportStar) || function(m, exports) {
-    for (var p in m) if (p !== "default" && !exports.hasOwnProperty(p)) __createBinding(exports, m, p);
+
+var e = this && this.__createBinding || (Object.create ? function(e, r, t, i) {
+  void 0 === i && (i = t), Object.defineProperty(e, i, {
+    enumerable: !0,
+    get: function() {
+      return r[t];
+    }
+  });
+} : function(e, r, t, i) {
+  void 0 === i && (i = t), e[i] = r[t];
+}), r = this && this.__exportStar || function(r, t) {
+  for (var i in r) "default" === i || t.hasOwnProperty(i) || e(t, r, i);
 };
-Object.defineProperty(exports, "__esModule", { value: true });
-exports.version = void 0;
-__exportStar(require("./Embeds"), exports);
-__exportStar(require("./FieldsEmbed"), exports);
-__exportStar(require("./base"), exports);
-// eslint-disable-next-line @typescript-eslint/no-var-requires
-exports.version = require('../package.json').version;
+
+Object.defineProperty(exports, "__esModule", {
+  value: !0
+}), exports.version = void 0, r(require("./Embeds"), exports), r(require("./FieldsEmbed"), exports), 
+r(require("./base"), exports), exports.version = require("../package.json").version;

--- a/bin/index.js
+++ b/bin/index.js
@@ -1,9 +1,18 @@
 "use strict";
-
-function e(e) {
-  for (var r in e) exports.hasOwnProperty(r) || (exports[r] = e[r]);
-}
-
-Object.defineProperty(exports, "__esModule", {
-  value: !0
-}), e(require("./Embeds")), e(require("./FieldsEmbed")), e(require("./base")), exports.version = require("../package.json").version;
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    Object.defineProperty(o, k2, { enumerable: true, get: function() { return m[k]; } });
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __exportStar = (this && this.__exportStar) || function(m, exports) {
+    for (var p in m) if (p !== "default" && !exports.hasOwnProperty(p)) __createBinding(exports, m, p);
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.version = void 0;
+__exportStar(require("./Embeds"), exports);
+__exportStar(require("./FieldsEmbed"), exports);
+__exportStar(require("./base"), exports);
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+exports.version = require('../package.json').version;


### PR DESCRIPTION
Previously, permission to manage messages was required in order to use this package. With this implementation, the permission to manage messages becomes an optional permission, and now the package can be used without that permission on a mandatory basis.

What the client does now is check first if they have permission to manage messages before things like: delete reply to client request message (skip pages), delete user reactions, etc. Now only if you have the permission to manage the messages, those methods do it, if not, you won't, but the package can still work without any problem, the paging works fine and the tried everything before doing this pull request.

Who benefits from this change?
It benefits public bots using this package on multiple servers where bots cannot handle messages, forcing them to look for another alternative to paging embeds. With this improvement, this permission will no longer be mandatory, if not, only optional

Example:
1. When a user reacts to a control, the client removes his reaction and executes the established action.
Now, only if the client has permission to manage messages, it will delete the user's reaction, then what the user has to do to go to the next page is to delete his reaction manually and press the reaction again, but if he has said permission it will execute his old function without any problem.

2. Before, when the user entered the page number by pressing the page break button, the client would delete the user's message and also delete their own information message.
Now the client will only delete his information message and not the user's message in the case of not having permission to manage messages, and if he has the permission he will delete both messages (from the user and the client).